### PR TITLE
Fix mobile horizontal overflow caused by unwrapped footer nav

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,6 @@ The site uses a fully custom Hugo theme (`reborn`) that is not designed as a reu
 
 Tailwind v4 is configured here via `@import "tailwindcss"`. The file also loads the Typography plugin and pulls class names from `hugo_stats.json` (Hugo's build stats, used for Tailwind's content scanning). The comment at the top of `main.css` notes this CSS logically belongs in the theme but couldn't be hosted there — keep it here.
 
-### Root `layouts/` overrides
-
-A small `layouts/partials/` directory at the repo root lets you override individual theme partials without touching `themes/reborn/`. Prefer adding overrides here rather than editing the theme directly when only a partial needs changing.
-
 ### Content structure
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Personal website of Mike Zornek ([mikezornek.com](https://mikezornek.com)), built with Hugo and a custom theme called `reborn`. The site is hosted as a static site on Render; `bin/build.sh` is the production build script used by Render.
+
+## Commands
+
+```bash
+# Install JS/CSS dependencies (Tailwind, Prettier plugins)
+npm install
+
+# Run local dev server (rebuilds on change)
+hugo server
+
+# Create a new blog post (draft by default)
+hugo new posts/2026/6/my-post-title/index.md
+
+# Format HTML templates and other files
+npx prettier --write .
+```
+
+There are no test commands — this is a content site with no automated test suite.
+
+## Architecture
+
+### Theme: `themes/reborn/`
+
+The site uses a fully custom Hugo theme (`reborn`) that is not designed as a reusable drop-in. Key subdirectories:
+
+- `themes/reborn/layouts/` — all Hugo templates (base layout, list/single/home pages, partials, shortcodes)
+- `themes/reborn/archetypes/default.md` — template used when running `hugo new`
+- `themes/reborn/assets/js/` — any theme JS
+
+### CSS: `assets/css/main.css`
+
+Tailwind v4 is configured here via `@import "tailwindcss"`. The file also loads the Typography plugin and pulls class names from `hugo_stats.json` (Hugo's build stats, used for Tailwind's content scanning). The comment at the top of `main.css` notes this CSS logically belongs in the theme but couldn't be hosted there — keep it here.
+
+### Root `layouts/` overrides
+
+A small `layouts/partials/` directory at the repo root lets you override individual theme partials without touching `themes/reborn/`. Prefer adding overrides here rather than editing the theme directly when only a partial needs changing.
+
+### Content structure
+
+```
+content/
+  posts/YYYY/M/post-slug/index.md   # blog posts
+  projects/project-name.md           # project pages
+  now.md, values.md, contact.md, …  # one-off pages
+```
+
+Post front matter fields (from the archetype):
+
+```yaml
+title: "Post Title"
+date: 2026-06-28T12:00:00-04:00
+description: something tweet-length
+images:
+  - posts/2026/6/post-slug/thumb.jpeg
+draft: true
+pain:   # optional: the problem this post addresses
+fix:    # optional: the resolution
+```
+
+### Hugo configuration
+
+`hugo.yaml` at the root. Notable settings:
+- `outputs.home` includes JSON (powers the search index at `content/search/`)
+- `build.buildStats` + `build.cachebusters` keep Tailwind in sync with Hugo's used-class list via `hugo_stats.json`
+
+### CI
+
+GitHub Actions runs Lighthouse CI (`lighthouse.yaml`) on every push to `main`, auditing a few key URLs against the budget in `.github/workflows/budget.json`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## What this is
+## About the project
 
 Personal website of Mike Zornek ([mikezornek.com](https://mikezornek.com)), built with Hugo and a custom theme called `reborn`. The site is hosted as a static site on Render; `bin/build.sh` is the production build script used by Render.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/codebook.toml
+++ b/codebook.toml
@@ -1,4 +1,5 @@
 words = [
     "Phillies",
     "Stardew",
+    "Zornek",
 ]

--- a/themes/reborn/layouts/partials/footer.html
+++ b/themes/reborn/layouts/partials/footer.html
@@ -2,7 +2,7 @@
   <div
     class="prose mx-auto mt-12 max-w-screen-md border-t-1 border-gray-200 text-center"
   >
-    <ol class="list-none flex justify-center gap-2">
+    <ol class="list-none flex flex-wrap justify-center gap-2">
       <li><a href="/">Home</a></li>
       <li><a href="/posts/">Blog</a></li>
       <li><a href="/elixir-consulting/">Elixir Consulting</a></li>

--- a/themes/reborn/layouts/partials/head.html
+++ b/themes/reborn/layouts/partials/head.html
@@ -1,5 +1,5 @@
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>
   {{ if .IsHome }}
     {{ site.Title }}


### PR DESCRIPTION
## Summary

- Added `flex-wrap` to the footer nav `<ol>` — eight items in a single unwrapped flex row exceeded the mobile viewport width (~390px), widening the body and causing everything (including the purple header) to stop short of the right edge.
- Added `initial-scale=1` to the viewport meta tag, which was missing from `head.html` (standard best practice, particularly important for iOS Safari).

Also includes an `AGENTS.md` file (with a `CLAUDE.md` symlink) documenting build commands and site architecture for AI coding assistants.

Before:

<img width="559" height="1062" alt="Screenshot 2026-06-28 at 11 01 01 AM" src="https://github.com/user-attachments/assets/acfe651b-4ec9-4577-8d73-b77817032bb0" />

After: 

<img width="559" height="1062" alt="Screenshot 2026-06-28 at 11 19 20 AM" src="https://github.com/user-attachments/assets/bb9a743e-6f1a-4eee-a32b-f7df494baa7d" />


