### PR TITLE
Modernize Lighthouse CI: fix budget assertions and update metrics

### DIFF
--- a/.github/workflows/budget.json
+++ b/.github/workflows/budget.json
@@ -1,53 +1,51 @@
 [
-    {
-      "path": "/*",
-      "resourceSizes": [
-        {
-          "resourceType": "total",
-          "budget": 200
-        }
-      ],
-      "timings": [
-        {
-          "metric": "first-contentful-paint",
-          "budget": 1000
-        },
-        {
-          "metric": "largest-contentful-paint",
-          "budget": 2000
-        },
-        {
-          "metric": "cumulative-layout-shift",
-          "budget": 0.1
-        },
-        {
-          "metric": "total-blocking-time",
-          "budget": 300
-        },
-        {
-          "metric": "speed-index",
-          "budget": 1000
-        },
-        {
-          "metric": "interactive",
-          "budget": 3500
-        },
-        {
-          "metric": "first-meaningful-paint",
-          "budget": 1000
-        },
-        {
-          "metric": "first-cpu-idle",
-          "budget": 2000
-        },
-        {
-          "metric": "max-potential-fid",
-          "budget": 100
-        },
-        {
-          "metric": "estimated-input-latency",
-          "budget": 50
-        }
-      ]
-    }
-  ]
+  {
+    "path": "/*",
+    "resourceSizes": [
+      {
+        "resourceType": "total",
+        "budget": 200
+      },
+      {
+        "resourceType": "script",
+        "budget": 50
+      },
+      {
+        "resourceType": "image",
+        "budget": 100
+      }
+    ],
+    "resourceCounts": [
+      {
+        "resourceType": "total",
+        "budget": 50
+      }
+    ],
+    "timings": [
+      {
+        "metric": "first-contentful-paint",
+        "budget": 1000
+      },
+      {
+        "metric": "largest-contentful-paint",
+        "budget": 2000
+      },
+      {
+        "metric": "cumulative-layout-shift",
+        "budget": 0.1
+      },
+      {
+        "metric": "total-blocking-time",
+        "budget": 200
+      },
+      {
+        "metric": "speed-index",
+        "budget": 1000
+      },
+      {
+        "metric": "interaction-to-next-paint",
+        "budget": 200
+      }
+    ]
+  }
+]

--- a/.github/workflows/lighthouse.yaml
+++ b/.github/workflows/lighthouse.yaml
@@ -7,7 +7,7 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Audit URLs using Lighthouse
         uses: treosh/lighthouse-ci-action@v12
         with:
@@ -15,6 +15,6 @@ jobs:
             https://mikezornek.com/
             https://mikezornek.com/posts/
             https://mikezornek.com/posts/2024/12/new-gaming-pc/
-          budgetPath: ./budget.json # test performance budgets
+          budgetPath: .github/workflows/budget.json
           uploadArtifacts: true # save results as an action artifacts
           temporaryPublicStorage: true # upload lighthouse report to the temporary storage


### PR DESCRIPTION
Related to #98

## Problem

The Lighthouse CI workflow was running audits but **never asserting against the budget** — the job appeared green while silently erroring on every run. The root cause was a wrong `budgetPath` (`./budget.json` instead of `.github/workflows/budget.json`), causing an `ENOENT` at the assert step.

Additionally, `budget.json` referenced five metrics that have since been removed from Lighthouse.

## Changes

**`lighthouse.yaml`**
- Fix `budgetPath` to `.github/workflows/budget.json` so assertions actually execute
- Bump `actions/checkout` from v4 to v7

**`budget.json`**
- Remove deprecated/removed metrics: `first-meaningful-paint`, `first-cpu-idle`, `max-potential-fid`, `estimated-input-latency`, `interactive` (TTI)
- Add `interaction-to-next-paint` at 200ms (Core Web Vital that replaced FID in 2024)
- Tighten `total-blocking-time` from 300ms → 200ms (Google's "good" threshold)
- Add per-type `resourceSizes` budgets: `script` (50kb), `image` (100kb)
- Add `resourceCounts` total budget (50 requests)

## Notes

FCP and Speed Index are budgeted at 1000ms, which is tighter than Google's "good" threshold of 1800ms. If CI starts failing on those after merge, loosening them to 1800ms would be appropriate.