### PR TITLE
Add "skip to main content" link for accessibility

### DIFF
--- a/themes/reborn/layouts/404.html
+++ b/themes/reborn/layouts/404.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <main>
+  <main id="main-content" tabindex="-1">
     <div class="mx-auto max-w-screen-md px-4 md:px-0">
       <div
         class="prose prose-p:leading-[1.5] prose-headings:mb-2 prose-a:text-purple-600 prose-a:visited:text-purple-900 max-w-none"

--- a/themes/reborn/layouts/_default/baseof.html
+++ b/themes/reborn/layouts/_default/baseof.html
@@ -7,6 +7,12 @@
     {{ partial "head.html" . }}
   </head>
   <body>
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-purple-600 focus:px-4 focus:py-2 focus:font-[Ubuntu] focus:font-bold focus:text-white focus:shadow-lg"
+    >
+      Skip to main content
+    </a>
     {{ partial "header.html" . }}
     {{ block "main" . }}{{ end }}
     {{ partial "footer.html" . }}

--- a/themes/reborn/layouts/_default/home.html
+++ b/themes/reborn/layouts/_default/home.html
@@ -1,5 +1,7 @@
 {{ define "main" }}
-  <div
+  <main
+    id="main-content"
+    tabindex="-1"
     class="prose prose-p:leading-[1.5] prose-headings:mb-2 prose-a:text-purple-600 prose-a:visited:text-purple-900 mx-auto max-w-screen-md px-4 md:px-0"
   >
     <h1 class="sr-only">Who is Mike Zornek?</h1>
@@ -27,8 +29,11 @@
       {{ partial "post-card.html" (dict "page" .) }}
     {{ end }}
 
+
     <p class="not-prose">
-      <a class="text-purple-700 hover:underline" href="/posts/">Browse all posts &rarr;</a>
+      <a class="text-purple-700 hover:underline" href="/posts/">
+        Browse all posts &rarr;
+      </a>
     </p>
-  </div>
+  </main>
 {{ end }}

--- a/themes/reborn/layouts/_default/list.html
+++ b/themes/reborn/layouts/_default/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <main>
+  <main id="main-content" tabindex="-1">
     <div class="mx-auto max-w-screen-md px-4 md:px-0">
       <div
         class="prose prose-p:leading-[1.5] prose-headings:mb-2 prose-a:text-purple-600 prose-a:visited:text-purple-900 max-w-none"

--- a/themes/reborn/layouts/_default/onepage.html
+++ b/themes/reborn/layouts/_default/onepage.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <main>
+  <main id="main-content" tabindex="-1">
     <div class="mx-auto max-w-screen-md px-4 md:px-0">
       {{/* Need to dry up this prose / width class component concept. */}}
       <article

--- a/themes/reborn/layouts/_default/search.html
+++ b/themes/reborn/layouts/_default/search.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <main>
+  <main id="main-content" tabindex="-1">
     <div class="mx-auto max-w-screen-md px-4 md:px-0">
       {{ partial "search-form.html" . }}
 

--- a/themes/reborn/layouts/_default/single.html
+++ b/themes/reborn/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <main>
+  <main id="main-content" tabindex="-1">
     <div class="mx-auto max-w-screen-md px-4 md:px-0">
       <article
         class="prose prose-p:leading-[1.5] prose-headings:mb-2 prose-a:text-purple-600 prose-a:visited:text-purple-900 max-w-none"

--- a/themes/reborn/layouts/_default/taxonomy.html
+++ b/themes/reborn/layouts/_default/taxonomy.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <main>
+  <main id="main-content" tabindex="-1">
     <div class="mx-auto max-w-screen-md px-4 md:px-0">
       <div
         class="prose prose-p:leading-[1.5] prose-headings:mb-2 prose-a:text-purple-600 prose-a:visited:text-purple-900 max-w-none"


### PR DESCRIPTION
## What & why

Adds a **"Skip to main content"** link so keyboard-only and screen-reader users can bypass the repeated header block (the Elixir-consulting banner, site title, social icons, and main nav — 8+ tab stops) and jump straight to the page's content.

This satisfies **[WCAG 2.4.1 Bypass Blocks (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html)** — one of the most fundamental accessibility success criteria (Level A is the baseline conformance level). Requested in #92, which references the Frontend Masters "Accessibility v3 — Keyboard-only tabbing" lesson teaching exactly this pattern.

## How it works

The skip link is the **first focusable element** in `<body>`, so it's the very first thing a keyboard user reaches when they start tabbing. It's visually hidden (`sr-only`) until it receives focus, at which point it appears as a purple pill in the top-left — matching the site's header styling so it reads as intentional. Activating it moves focus to the page's `<main>` element.

## Changes

- **`baseof.html`** — added the skip-link anchor (`href="#main-content"`) as the first child of `<body>`, using Tailwind's `sr-only` / `focus:not-sr-only` to show it only on focus.
- **`single.html`, `list.html`, `taxonomy.html`, `search.html`, `onepage.html`, `404.html`** — added `id="main-content"` and `tabindex="-1"` to the existing `<main>` element. The `tabindex="-1"` ensures browser focus actually lands on `<main>` when the link is followed (not just a scroll), so subsequent tabbing continues from the content.
- **`home.html`** — the homepage wrapped its content in a plain `<div>` and had **no `<main>` landmark at all**. Promoted that `<div>` to `<main id="main-content" tabindex="-1">`, which both provides the skip target and fixes a pre-existing missing-landmark gap on the site's most-visited page. (Prettier reflowed the adjacent "Browse all posts" link — no behavioral change.)
- `random.html` was intentionally left alone — it's a standalone redirect page that doesn't use `baseof` and immediately bounces the visitor to a random post.

## How to verify it as a keyboard user (macOS)

Run the site locally first:

```bash
hugo server
```

Then open <http://localhost:1313> and don't touch the mouse.

### ⚠️ One-time macOS setup (important)

macOS ships with a system-wide setting that controls whether <kbd>Tab</kbd> can move focus to links (not just text fields). Safari and, historically, Firefox honor it, and by default it's **off** — so if you skip this step, tabbing will appear to "not work" and you'll wrongly think the feature is broken.

- **System Settings → Keyboard → turn on "Keyboard navigation."** (On older macOS this lives under System Preferences → Keyboard → Shortcuts → "Use keyboard navigation to move focus between controls.")
- **Chrome** on macOS focuses links with <kbd>Tab</kbd> out of the box and does **not** require this setting — it's the easiest browser to test in.
- In **Safari** specifically, you can also move between focusable elements without the global setting by holding <kbd>Option</kbd> + <kbd>Tab</kbd>.

### The core test (any browser)

1. Load a page and click once in the address bar, then press <kbd>Tab</kbd> to move focus into the page — **or** just click on empty space near the top of the page and start tabbing.
2. **The very first <kbd>Tab</kbd> should reveal the skip link** — a purple "Skip to main content" pill appearing in the top-left corner. Before this change, that first Tab would instead land on the "Available now for Elixir…" banner link.
3. Press <kbd>Enter</kbd> (or <kbd>Return</kbd>) while the pill is focused.
4. Focus should jump **past** the entire header/nav to the main content. Confirm it worked two ways:
   - The URL gains a `#main-content` fragment.
   - The **next** <kbd>Tab</kbd> lands on a link *inside the content* (e.g. a link in the post body, or "Browse all posts" on the homepage) — **not** back on a nav item like Blog / Values / Now.
5. Press <kbd>Tab</kbd> again *without* activating the skip link to confirm the fallback path: focus should move off the pill and continue normally through the banner and nav, so nothing is trapped.

### Pages worth spot-checking

The skip target exists on every page type, so try one of each:

- **Homepage** (`/`) — the one that previously had no `<main>` landmark at all.
- **A blog post** (`/posts/…`) — `single.html`.
- **A list page** (`/posts/`) — `list.html`.
- **Search** (`/search/`) — `search.html`.
- **A 404** (visit any bogus URL like `/nope/`) — `404.html`.

### Optional: verify with VoiceOver (the real assistive-tech experience)

To hear it the way a screen-reader user would:

1. Toggle VoiceOver on with <kbd>Cmd</kbd> + <kbd>F5</kbd>.
2. Reload the page and press <kbd>Tab</kbd> — VoiceOver should announce **"Skip to main content, link."**
3. Activate it with <kbd>Ctrl</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>; VoiceOver should move into the main content region.
4. You can also press <kbd>Ctrl</kbd> + <kbd>Option</kbd> + <kbd>U</kbd> to open the rotor and confirm a **"main"** landmark now exists (including on the homepage).
5. Toggle VoiceOver back off with <kbd>Cmd</kbd> + <kbd>F5</kbd> when done.

## Build verification

- `hugo --gc --minify` builds cleanly (530 pages).
- Confirmed the rendered output contains the skip link and `#main-content` targets, and that Tailwind generated the new `focus:*` utility classes into the production CSS.

Closes #92