### PR TITLE
Accessible image figure system, trailing-slash-safe images, and an alt-text pass

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# Whitespace-sensitive Hugo templates that prettier-plugin-go-template mangles.
+#
+# These emit HTML where inter-attribute spacing is controlled by literal spaces
+# sitting next to `{{- ... }}` whitespace-trim markers. Prettier reflows the
+# attributes onto separate lines and drops those spaces, so the `{{-` trim then
+# glues attributes together (e.g. `alt="x"width="y"`) — malformed output. And
+# figure.html the plugin can't even print ("invalid node root"). See issue #114.
+themes/reborn/layouts/_markup/render-image.html
+themes/reborn/layouts/shortcodes/figure.html

--- a/content/posts/2018/9/elixirconf-2018-notes.md
+++ b/content/posts/2018/9/elixirconf-2018-notes.md
@@ -31,21 +31,21 @@ For more on Elixir check out [its homepage][2].
 
 ## Photos
 
-- ![][5]
-- ![][6]
-- ![][7]
-- ![][8]
-- ![][9]
-- ![][10]
-- ![][11]
-- ![][12]
-- ![][13]
-- ![][14]
-- ![][15]
-- ![][16]
-- ![][17]
-- ![][18]
-- ![][19]
+- ![A speaker gives a thumbs-up in front of a slide reading "Welcome back to… Building Production-Ready GraphQL APIs."][5]
+- ![Two ElixirConf attendees smile at the camera from a training-room table, laptops open in front of them.][6]
+- ![A conference slide titled "The power of open source" summarizing the 2018 Elixir ecosystem: 7,200+ libraries, 190+ meetups, 25+ books, and 15+ conferences.][7]
+- ![A Pulp Fiction meme of Samuel L. Jackson pointing a pistol, captioned "Say blockchain one more time."][8]
+- ![A sunny Bellevue park with a curved reflecting channel bordering a green lawn, trees, and downtown buildings in the distance.][9]
+- ![An ElixirConf attendee badge reading "Michael Zornek, Zorn Labs LLC, Bellevue, WA, September 4–7, 2018."][10]
+- ![Looking straight up through a circular glass-domed skylight in a hotel atrium, with surrounding towers visible through the glass.][11]
+- ![A cluster of attendees huddled around a laptop on stage in front of a 2018 ElixirConf US backdrop.][12]
+- ![An audience watching a talk whose screen reads "Ice Cream Driven Development," with the speaker at a lit podium.][13]
+- ![A keynote slide listing two bullets: "We started working on a type system" and "We stopped working on a type system."][14]
+- ![A large hotel ballroom full of attendees at round tables under chandeliers, facing a distant stage.][15]
+- ![A dimly lit training room where rows of attendees work on laptops, facing a projected slide.][16]
+- ![A Raspberry Pi touchscreen and a laptop both displaying a hand-drawn "It's Fine" sketch during a Nerves hardware demo.][17]
+- ![A Raspberry Pi board laid out on a table with its case pieces, a screwdriver, an SD card, and cables.][18]
+- ![A freestanding ElixirConf 2018 banner in a hallway, listing sponsors DockYard, POA, Plataformatec, and WM Engineering.][19]
 
 [1]: https://elixirconf.com
 [2]: https://elixir-lang.org

--- a/content/posts/2019/1/designing-a-modern-swift-network-stack-video-and-slides/index.md
+++ b/content/posts/2019/1/designing-a-modern-swift-network-stack-video-and-slides/index.md
@@ -20,22 +20,18 @@ When an app is young and has simple networking needs it's not uncommon to use UR
 
 In this talk I'll review the network design we've come up with. I'll demo what we have working and talk about how we want to extend it in the future. Attendee should walk away with new ideas that they can integrate into their own networking stacks.
 
-<figure>
-<img src="highres_477725961.jpeg" alt="Me presenting in a red polo shirt, gesturing beside my projected title slide 'Designing a Modern Swift Network Stack,' as attendees watch from a table." data-action="zoom">
-<figcaption>Philly CocoaHeads, Mike Zornek</figcaption>
-</figure>
+{{< figure src="highres_477725961.jpeg"
+  caption="Philly CocoaHeads, Mike Zornek"
+  alt="Me presenting in a red polo shirt, gesturing beside my projected title slide 'Designing a Modern Swift Network Stack,' as attendees watch from a table." >}}
 
-<figure>
-<img src="highres_477725960.jpeg" alt="A wide view of the Philly CocoaHeads meetup room: attendees at tables with laptops face the front, where I stand beside a screen reading 'Hello,' with pizza boxes on a side table." data-action="zoom">
-<figcaption>Philly CocoaHeads, Group Shot</figcaption>
-</figure>
+{{< figure src="highres_477725960.jpeg"
+  caption="Philly CocoaHeads, Group Shot"
+  alt="A wide view of the Philly CocoaHeads meetup room: attendees at tables with laptops face the front, where I stand beside a screen reading 'Hello,' with pizza boxes on a side table." >}}
 
-<figure>
-<img src="highres_477725968.jpeg" alt="Curtis Herbert presenting his Slopes skiing app on the projector at Philly CocoaHeads, with several attendees seated and watching." data-action="zoom">
-<figcaption>Philly CocoaHeads, Slopes</figcaption>
-</figure>
+{{< figure src="highres_477725968.jpeg"
+  caption="Philly CocoaHeads, Slopes"
+  alt="Curtis Herbert presenting his Slopes skiing app on the projector at Philly CocoaHeads, with several attendees seated and watching." >}}
 
-<figure>
-<img src="highres_477725971.jpeg" alt="The Philly CocoaHeads meetup room during a sponsor slide for 'The Meet Group,' attendees working on laptops at tables." data-action="zoom">
-<figcaption>Philly CocoaHeads, Group Shot</figcaption>
-</figure>
+{{< figure src="highres_477725971.jpeg"
+  caption="Philly CocoaHeads, Group Shot"
+  alt="The Philly CocoaHeads meetup room during a sponsor slide for 'The Meet Group,' attendees working on laptops at tables." >}}

--- a/content/posts/2019/1/designing-a-modern-swift-network-stack-video-and-slides/index.md
+++ b/content/posts/2019/1/designing-a-modern-swift-network-stack-video-and-slides/index.md
@@ -21,21 +21,21 @@ When an app is young and has simple networking needs it's not uncommon to use UR
 In this talk I'll review the network design we've come up with. I'll demo what we have working and talk about how we want to extend it in the future. Attendee should walk away with new ideas that they can integrate into their own networking stacks.
 
 <figure>
-<img src="highres_477725961.jpeg" alt="Philly CocoaHeads, Mike Zornek" data-action="zoom">
+<img src="highres_477725961.jpeg" alt="Me presenting in a red polo shirt, gesturing beside my projected title slide 'Designing a Modern Swift Network Stack,' as attendees watch from a table." data-action="zoom">
 <figcaption>Philly CocoaHeads, Mike Zornek</figcaption>
 </figure>
 
 <figure>
-<img src="highres_477725960.jpeg" alt="Philly CocoaHeads, Group Shot" data-action="zoom">
+<img src="highres_477725960.jpeg" alt="A wide view of the Philly CocoaHeads meetup room: attendees at tables with laptops face the front, where I stand beside a screen reading 'Hello,' with pizza boxes on a side table." data-action="zoom">
 <figcaption>Philly CocoaHeads, Group Shot</figcaption>
 </figure>
 
 <figure>
-<img src="highres_477725968.jpeg" alt="Philly CocoaHeads, Slopes" data-action="zoom">
+<img src="highres_477725968.jpeg" alt="Curtis Herbert presenting his Slopes skiing app on the projector at Philly CocoaHeads, with several attendees seated and watching." data-action="zoom">
 <figcaption>Philly CocoaHeads, Slopes</figcaption>
 </figure>
 
 <figure>
-<img src="highres_477725971.jpeg" alt="Philly CocoaHeads, Group Shot" data-action="zoom">
+<img src="highres_477725971.jpeg" alt="The Philly CocoaHeads meetup room during a sponsor slide for 'The Meet Group,' attendees working on laptops at tables." data-action="zoom">
 <figcaption>Philly CocoaHeads, Group Shot</figcaption>
 </figure>

--- a/content/posts/2019/1/professional-ios-projects-code-consistency-with-swiftlint/index.md
+++ b/content/posts/2019/1/professional-ios-projects-code-consistency-with-swiftlint/index.md
@@ -9,7 +9,7 @@ tags:
 
 > This article is part of a series, [Professional iOS Projects](/professional-ios-projects/).
 
-<img src="book-cover.jpg" style="float: right; width: 300px;" alt="A parody 'O RLY?' book cover spoofing O'Reilly, with a woodcut llama, titled 'Writing Code that Nobody Else Can Read: The Definitive Guide.' The top tagline reads 'Does it run? Just leave it alone.' Credited to @ThePracticalDev." data-action="zoom">
+<img src="book-cover.jpg" style="float: right; width: 300px;" alt="A parody 'O RLY?' book cover spoofing O'Reilly, with a woodcut llama, titled 'Writing Code that Nobody Else Can Read: The Definitive Guide.' The top tagline reads 'Does it run? Just leave it alone.' Credited to @ThePracticalDev.">
 
 Have you ever opened a source file and knew instantly it was written by a specific member of the team because of all the curious syntax choices they made? Perhaps they are green and don’t know the community standards or perhaps they spend most of their days in another language which has its own preferred style. What do you do?
 

--- a/content/posts/2019/1/professional-ios-projects-code-consistency-with-swiftlint/index.md
+++ b/content/posts/2019/1/professional-ios-projects-code-consistency-with-swiftlint/index.md
@@ -9,7 +9,7 @@ tags:
 
 > This article is part of a series, [Professional iOS Projects](/professional-ios-projects/).
 
-<img src="book-cover.jpg" style="float: right; width: 300px;" alt="Book Cover: Writing Code No One Else Can Read" data-action="zoom">
+<img src="book-cover.jpg" style="float: right; width: 300px;" alt="A parody 'O RLY?' book cover spoofing O'Reilly, with a woodcut llama, titled 'Writing Code that Nobody Else Can Read: The Definitive Guide.' The top tagline reads 'Does it run? Just leave it alone.' Credited to @ThePracticalDev." data-action="zoom">
 
 Have you ever opened a source file and knew instantly it was written by a specific member of the team because of all the curious syntax choices they made? Perhaps they are green and don’t know the community standards or perhaps they spend most of their days in another language which has its own preferred style. What do you do?
 
@@ -42,7 +42,7 @@ fi
 ```
 
 <figure>
-<img src="xcode-build-phase.png" alt="Xcode Build Phase Editor" data-action="zoom">
+<img src="xcode-build-phase.png" alt="An Xcode Run Script build phase containing a shell snippet that runs SwiftLint if installed, or prints a 'SwiftLint not installed' warning otherwise." data-action="zoom">
 <figcaption>Xcode Build Phase Editor</figcaption>
 </figure>
 
@@ -53,7 +53,7 @@ This script will look for the `swiftlint` command line tool. If found, it will r
 With `swiftlint` installed and your Xcode project setup, you now will experience new inline warnings and errors, helping to identify code that might lean away from community standards. Sometimes the warnings or errors will even offer automated fix options too.
 
 <figure>
-<img src="xcode-editor.png" alt="Warnings and Errors in Xcode Editor" data-action="zoom">
+<img src="xcode-editor.png" alt="Swift code in Xcode with inline SwiftLint annotations: a red Force Cast Violation and a yellow Colon Violation flagged beside the offending lines." data-action="zoom">
 <figcaption>Warnings and Errors in Xcode Editor</figcaption>
 </figure>
 

--- a/content/posts/2019/1/professional-ios-projects-code-consistency-with-swiftlint/index.md
+++ b/content/posts/2019/1/professional-ios-projects-code-consistency-with-swiftlint/index.md
@@ -9,6 +9,11 @@ tags:
 
 > This article is part of a series, [Professional iOS Projects](/professional-ios-projects/).
 
+<!-- Left as raw HTML on purpose: this cover floats right beside the text, a
+     layout the centered `figure` shortcode isn't meant to express. The tradeoff
+     is that the relative `src` stays trailing-slash sensitive (issue #90) — it
+     only loads on the canonical `.../slug/` URL. Revisit if the shortcode ever
+     grows a float/inline variant. -->
 <img src="book-cover.jpg" style="float: right; width: 300px;" alt="A parody 'O RLY?' book cover spoofing O'Reilly, with a woodcut llama, titled 'Writing Code that Nobody Else Can Read: The Definitive Guide.' The top tagline reads 'Does it run? Just leave it alone.' Credited to @ThePracticalDev.">
 
 Have you ever opened a source file and knew instantly it was written by a specific member of the team because of all the curious syntax choices they made? Perhaps they are green and don’t know the community standards or perhaps they spend most of their days in another language which has its own preferred style. What do you do?

--- a/content/posts/2019/1/professional-ios-projects-code-consistency-with-swiftlint/index.md
+++ b/content/posts/2019/1/professional-ios-projects-code-consistency-with-swiftlint/index.md
@@ -41,10 +41,9 @@ else
 fi
 ```
 
-<figure>
-<img src="xcode-build-phase.png" alt="An Xcode Run Script build phase containing a shell snippet that runs SwiftLint if installed, or prints a 'SwiftLint not installed' warning otherwise." data-action="zoom">
-<figcaption>Xcode Build Phase Editor</figcaption>
-</figure>
+{{< figure src="xcode-build-phase.png"
+  caption="Xcode Build Phase Editor"
+  alt="An Xcode Run Script build phase containing a shell snippet that runs SwiftLint if installed, or prints a 'SwiftLint not installed' warning otherwise." >}}
 
 This script will look for the `swiftlint` command line tool. If found, it will run it on your project's source files. If not found, it will still allow the build to finish but will post a short message to the console.
 
@@ -52,10 +51,9 @@ This script will look for the `swiftlint` command line tool. If found, it will r
 
 With `swiftlint` installed and your Xcode project setup, you now will experience new inline warnings and errors, helping to identify code that might lean away from community standards. Sometimes the warnings or errors will even offer automated fix options too.
 
-<figure>
-<img src="xcode-editor.png" alt="Swift code in Xcode with inline SwiftLint annotations: a red Force Cast Violation and a yellow Colon Violation flagged beside the offending lines." data-action="zoom">
-<figcaption>Warnings and Errors in Xcode Editor</figcaption>
-</figure>
+{{< figure src="xcode-editor.png"
+  caption="Warnings and Errors in Xcode Editor"
+  alt="Swift code in Xcode with inline SwiftLint annotations: a red Force Cast Violation and a yellow Colon Violation flagged beside the offending lines." >}}
 
 ## Customizing the Rules
 

--- a/content/posts/2019/2/professional-ios-projects-code-documentation/index.md
+++ b/content/posts/2019/2/professional-ios-projects-code-documentation/index.md
@@ -65,9 +65,11 @@ To add documentation use three slashes `///` to start a line of documentation. Y
 
 > In Xcode you can also use `Option+Command+/` to bulk paste a documentation line template. This template is particularly useful when documenting a method with lots of parameters and other parts.
 
-<img src="xcode-menu.png" alt="Xcode's Editor menu with the Structure submenu open and 'Add Documentation' highlighted." data-action="zoom">
+{{< figure src="xcode-menu.png"
+  alt="Xcode's Editor menu with the Structure submenu open and 'Add Documentation' highlighted." >}}
 
-<img src="adding-documentation.gif" alt="An animation of Xcode inserting a documentation-comment template above a configure(...) method after choosing Add Documentation." data-action="zoom">
+{{< figure src="adding-documentation.gif"
+  alt="An animation of Xcode inserting a documentation-comment template above a configure(...) method after choosing Add Documentation." >}}
 
 Swift documentation supports Markdown and if you backtick mentions of a type it often will generate a link to that type when the documentation is rendered in Xcode.
 
@@ -112,13 +114,15 @@ class ContactStore {
 
 In this second example we use `MARK: - SectionName`. This helps split up our source file. In particular since we don’t have headers anymore I like how I can segregate `private` methods to the bottom.
 
-<img src="method-popup.png" alt="An Xcode symbol popup for a ContactStore class listing its Properties, Methods, and Private members, including a contains method flagged with a to-do note." data-action="zoom">
+{{< figure src="method-popup.png"
+  alt="An Xcode symbol popup for a ContactStore class listing its Properties, Methods, and Private members, including a contains method flagged with a to-do note." >}}
 
 Another example here includes the use of `//FIXME`. FIXME is not triple slashed so it’s not technically documentation but it will be showcased inside of Xcode’s editor.
 
 The main way you’ll encounter this documentation is through Xcode’s Quick Help. Option click a method and you’ll see:
 
-<img src="quickhelp.png" alt="Xcode's Quick Help popover for a contains(_:) method, showing the summary, declaration, parameter, and return description drawn from its documentation comments." data-action="zoom">
+{{< figure src="quickhelp.png"
+  alt="Xcode's Quick Help popover for a contains(_:) method, showing the summary, declaration, parameter, and return description drawn from its documentation comments." >}}
 
 Sadly there is no official support for HTML generation but there are third party tools like [Jazzy](https://github.com/realm/jazzy) that can help.
 

--- a/content/posts/2019/2/professional-ios-projects-code-documentation/index.md
+++ b/content/posts/2019/2/professional-ios-projects-code-documentation/index.md
@@ -65,9 +65,9 @@ To add documentation use three slashes `///` to start a line of documentation. Y
 
 > In Xcode you can also use `Option+Command+/` to bulk paste a documentation line template. This template is particularly useful when documenting a method with lots of parameters and other parts.
 
-<img src="xcode-menu.png" alt="Xcode Menu, Add Documentation" data-action="zoom">
+<img src="xcode-menu.png" alt="Xcode's Editor menu with the Structure submenu open and 'Add Documentation' highlighted." data-action="zoom">
 
-<img src="adding-documentation.gif" alt="Inline Editor Adding Documentation" data-action="zoom">
+<img src="adding-documentation.gif" alt="An animation of Xcode inserting a documentation-comment template above a configure(...) method after choosing Add Documentation." data-action="zoom">
 
 Swift documentation supports Markdown and if you backtick mentions of a type it often will generate a link to that type when the documentation is rendered in Xcode.
 
@@ -112,13 +112,13 @@ class ContactStore {
 
 In this second example we use `MARK: - SectionName`. This helps split up our source file. In particular since we don’t have headers anymore I like how I can segregate `private` methods to the bottom.
 
-<img src="method-popup.png" alt="Xcode Method Popup" data-action="zoom">
+<img src="method-popup.png" alt="An Xcode symbol popup for a ContactStore class listing its Properties, Methods, and Private members, including a contains method flagged with a to-do note." data-action="zoom">
 
 Another example here includes the use of `//FIXME`. FIXME is not triple slashed so it’s not technically documentation but it will be showcased inside of Xcode’s editor.
 
 The main way you’ll encounter this documentation is through Xcode’s Quick Help. Option click a method and you’ll see:
 
-<img src="quickhelp.png" alt="Xcode Quick Help" data-action="zoom">
+<img src="quickhelp.png" alt="Xcode's Quick Help popover for a contains(_:) method, showing the summary, declaration, parameter, and return description drawn from its documentation comments." data-action="zoom">
 
 Sadly there is no official support for HTML generation but there are third party tools like [Jazzy](https://github.com/realm/jazzy) that can help.
 

--- a/content/posts/2020/6/book-dreaming-in-code/index.md
+++ b/content/posts/2020/6/book-dreaming-in-code/index.md
@@ -9,7 +9,7 @@ tags:
   - reviews
 ---
 
-<img src="thumnb.jpeg" alt="Dreaming in Code book cover." style="width:auto;">
+{{< figure src="thumnb.jpeg" link="false" alt="Dreaming in Code book cover." >}}
 
 Dreaming in Code is a book by Scott Rosenberg. On [the book website](http://www.dreamingincode.com/) he write:
 

--- a/content/posts/2021/11/book-thoughts-company-of-one/index.md
+++ b/content/posts/2021/11/book-thoughts-company-of-one/index.md
@@ -9,10 +9,7 @@ tags:
   - reviews
 ---
 
-<figure style="width: 30%; margin: 0;">
-<img src="book-cover.jpg" alt="Company of One Book Cover" data-action="zoom">
-<figcaption>Company of One Book Cover</figcaption>
-</figure>
+{{< figure src="book-cover.jpg" width="30%" alt="Company of One Book Cover" >}}
 
 This weekend I finished [Company of One] by Paul Jarvis. The book pitches:
 

--- a/content/posts/2021/3/retro-taxi-project-kickoff/index.md
+++ b/content/posts/2021/3/retro-taxi-project-kickoff/index.md
@@ -32,7 +32,7 @@ The [first](https://github.com/phoenix-by-example/greeter) [two](https://github.
 
 <figure>
  <a href="breadboards.jpeg">
- <img src="breadboards-thumb.jpeg" alt="Sample of some early discovery sketching and interface breadboarding."></a>
+ <img src="breadboards-thumb.jpeg" alt="An early hand-drawn iPad sketch of the retro board's Start, Stop, and Continue columns, annotated with notes about hiding the add buttons between phases and signaling when others are writing."></a>
  <figcaption>Sample of some early discovery sketching and interface <a href="https://basecamp.com/shapeup/1.3-chapter-04#breadboarding">breadboarding</a>.</figcaption>
 </figure>
 
@@ -40,13 +40,13 @@ Some mockups from the pitch document:
 
 <figure>
  <a href="board-layout.png">
- <img src="board-layout-thumb.jpeg" alt="Board layout."></a>
+ <img src="board-layout-thumb.jpeg" alt="A low-fidelity wireframe of the retro board web page: a header with board settings and participant info above four columns -- Start, Stop, Continue, and Actions -- each holding card slots."></a>
  <figcaption>Board layout.</figcaption>
 </figure>
 
 <figure>
  <a href="card-state.png">
- <img src="card-state-thumb.jpeg" alt="Card state."></a>
+ <img src="card-state-thumb.jpeg" alt="An annotated mockup of a retro board column showing a topic card's states -- editable text, a vote button, an inline vote count, and a voted state -- with margin notes explaining each."></a>
  <figcaption>Card state.</figcaption>
 </figure>
 

--- a/content/posts/2021/3/retro-taxi-project-kickoff/index.md
+++ b/content/posts/2021/3/retro-taxi-project-kickoff/index.md
@@ -30,25 +30,19 @@ RetroTaxi will utilize [Phoenix LiveView](https://hexdocs.pm/phoenix_live_view/P
 
 The [first](https://github.com/phoenix-by-example/greeter) [two](https://github.com/phoenix-by-example/get_shorty) projects of Phoenix by Example were fairly simplistic in nature and one of the first goals is of RetroTaxi is to do **a more through exploration of a real world project process**. As such you'll see some early discovery time has been spent in preparing [a pitch document](https://github.com/phoenix-by-example/retro_taxi/blob/main/docs/c1/feature_post_and_vote.md), which is a slice of the larger Shape Up process.
 
-<figure>
- <a href="breadboards.jpeg">
- <img src="breadboards-thumb.jpeg" alt="An early hand-drawn iPad sketch of the retro board's Start, Stop, and Continue columns, annotated with notes about hiding the add buttons between phases and signaling when others are writing."></a>
- <figcaption>Sample of some early discovery sketching and interface <a href="https://basecamp.com/shapeup/1.3-chapter-04#breadboarding">breadboarding</a>.</figcaption>
-</figure>
+{{< figure src="breadboards-thumb.jpeg" link="breadboards.jpeg"
+  caption="Sample of some early discovery sketching and interface <a href='https://basecamp.com/shapeup/1.3-chapter-04#breadboarding'>breadboarding</a>."
+  alt="An early hand-drawn iPad sketch of the retro board's Start, Stop, and Continue columns, annotated with notes about hiding the add buttons between phases and signaling when others are writing." >}}
 
 Some mockups from the pitch document:
 
-<figure>
- <a href="board-layout.png">
- <img src="board-layout-thumb.jpeg" alt="A low-fidelity wireframe of the retro board web page: a header with board settings and participant info above four columns -- Start, Stop, Continue, and Actions -- each holding card slots."></a>
- <figcaption>Board layout.</figcaption>
-</figure>
+{{< figure src="board-layout-thumb.jpeg" link="board-layout.png"
+  caption="Board layout."
+  alt="A low-fidelity wireframe of the retro board web page: a header with board settings and participant info above four columns -- Start, Stop, Continue, and Actions -- each holding card slots." >}}
 
-<figure>
- <a href="card-state.png">
- <img src="card-state-thumb.jpeg" alt="An annotated mockup of a retro board column showing a topic card's states -- editable text, a vote button, an inline vote count, and a voted state -- with margin notes explaining each."></a>
- <figcaption>Card state.</figcaption>
-</figure>
+{{< figure src="card-state-thumb.jpeg" link="card-state.png"
+  caption="Card state."
+  alt="An annotated mockup of a retro board column showing a topic card's states -- editable text, a vote button, an inline vote count, and a voted state -- with margin notes explaining each." >}}
 
 The second project goal is to (hopefully) **provide more useful and usable solutions to real world problems**. When I built the [GetShorty](https://github.com/phoenix-by-example/get_shorty) link shortener example there were no real aspirations that anyone would actually use the tool day-to-day, but moving forward I'd like to find small slices of opinionated, usefulness solutions to model the examples after. If you find this and have thoughts on retro meeting and the tools involved, please [reach out](mailto:mike@mikezornek.com). I'd love to hear your observations.
 

--- a/content/posts/2021/6/programming-terminology/index.md
+++ b/content/posts/2021/6/programming-terminology/index.md
@@ -37,11 +37,9 @@ Sometimes when we talk about entities we'll get into the deeper discussions of h
 
 As you define the core domain nouns of your app you'll inevitably start to build out a series of modules that help you manage these nouns. When designing the interfaces of these modules have an explicit pattern for how to name behaviors and try when possible to lean on community patterns. Ask yourself, "how does the Elixir language or popular frameworks use these terms?"
 
-<figure class="">
- <a href="delete-new-search.png">
- <img class="" style="max-width: 50%; "src="delete-new-search.png" alt="Two side-by-side Elixir documentation searches: 'delete' returning functions like Keyword.delete/2 and List.delete/2, and 'new' returning Date.new/4, DateTime.new/4, and similar constructors."></a>
- <figcaption class="">Delete and New as used inside of Elixir.</figcaption>
-</figure>
+{{< figure src="delete-new-search.png" width="50%"
+  caption="Delete and New as used inside of Elixir."
+  alt="Two side-by-side Elixir documentation searches: 'delete' returning functions like Keyword.delete/2 and List.delete/2, and 'new' returning Date.new/4, DateTime.new/4, and similar constructors." >}}
 
 You can also take advantage of the various Phoenix/Ecto generates for a peek at some pattern recommendations from the framework authors. These are usually a great place to start, although I don't consider the patterns to be gospel.
 

--- a/content/posts/2021/6/programming-terminology/index.md
+++ b/content/posts/2021/6/programming-terminology/index.md
@@ -39,7 +39,7 @@ As you define the core domain nouns of your app you'll inevitably start to build
 
 <figure class="">
  <a href="delete-new-search.png">
- <img class="" style="max-width: 50%; "src="delete-new-search.png" alt="Delete and New as used inside of Elixir."></a>
+ <img class="" style="max-width: 50%; "src="delete-new-search.png" alt="Two side-by-side Elixir documentation searches: 'delete' returning functions like Keyword.delete/2 and List.delete/2, and 'new' returning Date.new/4, DateTime.new/4, and similar constructors."></a>
  <figcaption class="">Delete and New as used inside of Elixir.</figcaption>
 </figure>
 

--- a/content/posts/2021/9/ecto-schemaless-changesets/index.md
+++ b/content/posts/2021/9/ecto-schemaless-changesets/index.md
@@ -51,10 +51,9 @@ Lets explain.
 
 First, having any chunk of code touch too many layers begins to handicap your ability to refactor. I tend to align with the thought that "Good Code Is Easy To Change Code". If you are looking for a simple measurement when evaluating the quality of a codebase, changeability is as good as any principle to lean on.
 
-<figure>
- <img src="layers.png" alt="A diagram of four stacked layers in a Phoenix app with arrows flowing between them: an HTML form, ProfileController.edit/2, Accounts.change_user/2, and User.changeset/2.">
- <figcaption>A common but brittle approach that creates strong dependencies across all the layers.</figcaption>
-</figure>
+{{< figure src="layers.png" link="false"
+  caption="A common but brittle approach that creates strong dependencies across all the layers."
+  alt="A diagram of four stacked layers in a Phoenix app with arrows flowing between them: an HTML form, ProfileController.edit/2, Accounts.change_user/2, and User.changeset/2." >}}
 
 Second, having low stack changesets dictate web form behavior creates a dysfunctional approach to user experience design where you force the user to represent their work as it will (eventually) be persisted in a database table row. In an ideal situation you'll be crafting custom web forms to capture user intent and then transform the incoming data into the needed persistance format. Do not let the database dictate the user interface!
 

--- a/content/posts/2021/9/ecto-schemaless-changesets/index.md
+++ b/content/posts/2021/9/ecto-schemaless-changesets/index.md
@@ -52,7 +52,7 @@ Lets explain.
 First, having any chunk of code touch too many layers begins to handicap your ability to refactor. I tend to align with the thought that "Good Code Is Easy To Change Code". If you are looking for a simple measurement when evaluating the quality of a codebase, changeability is as good as any principle to lean on.
 
 <figure>
- <img src="layers.png" alt="Visual showing four layers of a typical Phoenix app.">
+ <img src="layers.png" alt="A diagram of four stacked layers in a Phoenix app with arrows flowing between them: an HTML form, ProfileController.edit/2, Accounts.change_user/2, and User.changeset/2.">
  <figcaption>A common but brittle approach that creates strong dependencies across all the layers.</figcaption>
 </figure>
 

--- a/content/posts/2021/9/retro-taxi-sept-2021-update/index.md
+++ b/content/posts/2021/9/retro-taxi-sept-2021-update/index.md
@@ -17,21 +17,17 @@ From the scope of the [original pitch document](https://github.com/elixirfocus/r
 
 First, a user can visit the home page and create a new board. This create board form also asks for their name, since they will be displayed as the meeting's facilitator to future collaborators.
 
-<figure>
- <a href="new-board.png">
- <img src="new-board-thumb.png" alt="The RetroTaxi 'Create Board' form in a browser, with board name and facilitator name fields ('Demos are Good' and 'Mike Zornek') above a yellow Create Board button."></a>
- <figcaption>Create new board form.</figcaption>
-</figure>
+{{< figure src="new-board-thumb.png" link="new-board.png"
+  caption="Create new board form."
+  alt="The RetroTaxi 'Create Board' form in a browser, with board name and facilitator name fields ('Demos are Good' and 'Mike Zornek') above a yellow Create Board button." >}}
 
 With the board created you are redirected to the board page, which shows the custom title and displays the facilitator in the to-be-fleshed-out "who's here" section.
 
 Each board has four columns and each column has content cards. You can add cards to columns and you can edit cards. There is no active pub/sub between multiple people viewing the board and seeing the cards change (yet), that is still forthcoming.
 
-<figure>
- <a href="board-columns.png">
- <img src="board-columns-thumb.png" alt="A RetroTaxi board titled 'Demos are Good' with Start, Stop, Continue, and Actions columns of blue topic cards, each with a vote button; one card is open in an editable state."></a>
- <figcaption>Sample of current board with editable content cards.</figcaption>
-</figure>
+{{< figure src="board-columns-thumb.png" link="board-columns.png"
+  caption="Sample of current board with editable content cards."
+  alt="A RetroTaxi board titled 'Demos are Good' with Start, Stop, Continue, and Actions columns of blue topic cards, each with a vote button; one card is open in an editable state." >}}
 
 The site is styled with Tailwind CSS through I wouldn't say it represents a final visual language by any means. I hope to finish the project with a vanilla Phoenix LiveView setup and then move on to experiment with [Surface](https://surface-ui.org/) for a fuller UI component experience.
 

--- a/content/posts/2021/9/retro-taxi-sept-2021-update/index.md
+++ b/content/posts/2021/9/retro-taxi-sept-2021-update/index.md
@@ -19,7 +19,7 @@ First, a user can visit the home page and create a new board. This create board 
 
 <figure>
  <a href="new-board.png">
- <img src="new-board-thumb.png" alt="Create new board form."></a>
+ <img src="new-board-thumb.png" alt="The RetroTaxi 'Create Board' form in a browser, with board name and facilitator name fields ('Demos are Good' and 'Mike Zornek') above a yellow Create Board button."></a>
  <figcaption>Create new board form.</figcaption>
 </figure>
 
@@ -29,7 +29,7 @@ Each board has four columns and each column has content cards. You can add cards
 
 <figure>
  <a href="board-columns.png">
- <img src="board-columns-thumb.png" alt="Sample of current board with editable content cards."></a>
+ <img src="board-columns-thumb.png" alt="A RetroTaxi board titled 'Demos are Good' with Start, Stop, Continue, and Actions columns of blue topic cards, each with a vote button; one card is open in an editable state."></a>
  <figcaption>Sample of current board with editable content cards.</figcaption>
 </figure>
 

--- a/content/posts/2022/10/elixir-book-club-testing-book/index.md
+++ b/content/posts/2022/10/elixir-book-club-testing-book/index.md
@@ -16,10 +16,7 @@ Starting Sunday, November 13th at 10:30am (Eastern Time), we'll meet for an hour
 
 ## Testing Elixir
 
-<figure style="width: 40%; margin: 0 auto;">
-<img src="testing-elixir.jpg" alt="Testing Elixir Book Cover" data-action="zoom">
-<figcaption>Testing Elixir Book Cover</figcaption>
-</figure>
+{{< figure src="testing-elixir.jpg" width="40%" alt="Testing Elixir Book Cover" >}}
 
 <https://pragprog.com/titles/lmelixir/testing-elixir/>
 
@@ -33,10 +30,7 @@ To participate, you'll need to [join the Elixir Book Club Discord](https://disco
 
 If you are interested in software testing, I HIGHLY recommend this other book as well: U**nit Testing Principles, Practices, and Patterns**.
 
-<figure style="width: 40%; margin: 0 auto;">
-<img src="unit-testing.jpg" alt="Unit Testing Principles, Practices, and Patterns Book Cover" data-action="zoom">
-<figcaption>Unit Testing Principles, Practices, and Patterns Book Cover</figcaption>
-</figure>
+{{< figure src="unit-testing.jpg" width="40%" alt="Unit Testing Principles, Practices, and Patterns Book Cover" >}}
 
 <https://www.manning.com/books/unit-testing>
 

--- a/content/posts/2022/11/4-journal-estimate-wins/index.md
+++ b/content/posts/2022/11/4-journal-estimate-wins/index.md
@@ -13,9 +13,8 @@ This week I completed my third week with a new client. It was a notably challeng
 
 The goal of this estimate is to, in a time-boxed format, create a framework for more meaningful discussions to happen. These numbers should not be looked at as facts but shape those first steps of discovery.
 
-<figure style="width: 50%; margin: 0 auto;">
-<img src="deadlines.jpg" alt="The Austin Powers meme of Dr. Evil and his henchmen laughing together, captioned: 'We'll ask for estimates and then treat them as deadlines.'" data-action="zoom">
-</figure>
+{{< figure src="deadlines.jpg" width="50%"
+  alt="The Austin Powers meme of Dr. Evil and his henchmen laughing together, captioned: 'We'll ask for estimates and then treat them as deadlines.'" >}}
 
 A few notes and observations:
 

--- a/content/posts/2022/11/4-journal-estimate-wins/index.md
+++ b/content/posts/2022/11/4-journal-estimate-wins/index.md
@@ -14,7 +14,7 @@ This week I completed my third week with a new client. It was a notably challeng
 The goal of this estimate is to, in a time-boxed format, create a framework for more meaningful discussions to happen. These numbers should not be looked at as facts but shape those first steps of discovery.
 
 <figure style="width: 50%; margin: 0 auto;">
-<img src="deadlines.jpg" alt="Meme: We'll ask for estimates, and treat them as deadlines. Evil laughing." data-action="zoom">
+<img src="deadlines.jpg" alt="The Austin Powers meme of Dr. Evil and his henchmen laughing together, captioned: 'We'll ask for estimates and then treat them as deadlines.'" data-action="zoom">
 </figure>
 
 A few notes and observations:

--- a/content/posts/2022/11/my-standup-format/index.md
+++ b/content/posts/2022/11/my-standup-format/index.md
@@ -13,8 +13,7 @@ I find async standups to be a productive and low-cost ceremony in my development
 An async standup, in short, is each day, typically in the morning hours, team members are asked to post an update about what is going on in their work. This post is not about time tracking or otherwise work inspection but more an opportunity to take a breath, celebrate your wins, acknowledge your losses, ask for help and share your plans. A good outcome of standups is ensuring you get the help you need from your team to be successful .
 
 <figure style="width: 70%; margin: 0 auto;">
-<img src="we-are-fine.jpg" alt="StarWars: WHEN PROJECT MANAGER ASKING FOR UPDATE AT STANDUP CALL --
-WE ARE FINE WE ARE ALL FINE NOW. HOW ARE YOU?" data-action="zoom">
+<img src="we-are-fine.jpg" alt="The Star Wars scene of Han Solo in stormtrooper armor speaking into the detention-block intercom, captioned: when the project manager asks for an update at the standup call -- 'We are fine. We are all fine now. How are you?'" data-action="zoom">
 </figure>
 
 There is an async standup format I've been using for over a year now, and since it seems to be sticking, I figured I'd take a moment to share it and explain why I like it.

--- a/content/posts/2022/11/my-standup-format/index.md
+++ b/content/posts/2022/11/my-standup-format/index.md
@@ -12,9 +12,8 @@ I find async standups to be a productive and low-cost ceremony in my development
 
 An async standup, in short, is each day, typically in the morning hours, team members are asked to post an update about what is going on in their work. This post is not about time tracking or otherwise work inspection but more an opportunity to take a breath, celebrate your wins, acknowledge your losses, ask for help and share your plans. A good outcome of standups is ensuring you get the help you need from your team to be successful .
 
-<figure style="width: 70%; margin: 0 auto;">
-<img src="we-are-fine.jpg" alt="The Star Wars scene of Han Solo in stormtrooper armor speaking into the detention-block intercom, captioned: when the project manager asks for an update at the standup call -- 'We are fine. We are all fine now. How are you?'" data-action="zoom">
-</figure>
+{{< figure src="we-are-fine.jpg" width="70%"
+  alt="The Star Wars scene of Han Solo in stormtrooper armor speaking into the detention-block intercom, captioned: when the project manager asks for an update at the standup call -- 'We are fine. We are all fine now. How are you?'" >}}
 
 There is an async standup format I've been using for over a year now, and since it seems to be sticking, I figured I'd take a moment to share it and explain why I like it.
 

--- a/content/posts/2022/11/thank-you-phillies/index.md
+++ b/content/posts/2022/11/thank-you-phillies/index.md
@@ -10,12 +10,7 @@ series:
 
 This weekend the Phillies lost the World Series to the Houston Astros. Of course, this is a disappointing loss, but overall I look back on the 2022 season with immense pride for my team and offer particular thanks for giving me so much enjoyment during a time of personal need.
 
-<figure style="width: 70%; margin: 0 auto;">
-<a href="zorn-at-the-bank.jpeg">
-<img src="zorn-at-the-bank.jpeg" alt="Zorn at Citizens Bank Park wearing a Phillies cap." data-action="zoom">
-</a>
-<figcaption>Zorn at Citizens Bank Park wearing a Phillies cap.</figcaption>
-</figure>
+{{< figure src="zorn-at-the-bank.jpeg" width="70%" alt="Zorn at Citizens Bank Park wearing a Phillies cap." >}}
 
 With the loss of my mother in early February, I was greatly looking to the upcoming baseball season as a chance for escape. I've always been a baseball fan (my high school years being a notable peak), but this year's distraction opportunity would be very welcome.
 

--- a/content/posts/2022/12/17-journal/index.md
+++ b/content/posts/2022/12/17-journal/index.md
@@ -10,10 +10,17 @@ series:
 
 Saturday, December 17, 2022 -- This weekend kicked off with some dedicated time to my office. On Friday, I caught up on a stack of mail/bills/paperwork, and then today got over the hump of cleaning up the office itself. It's the first time since moving in during October that the office has been fully cleaned and set up. No boxes or random crap in the corner. It's all tidy and feels great.
 
-![](IMG_2046.jpeg)
-![](IMG_2047.jpeg)
-![](IMG_2048.jpeg)
-![](IMG_2049.jpeg)
+{{< figure src="IMG_2046.jpeg"
+  alt="A tidy home office with an L-shaped butcher-block desk holding a laptop and dual monitors, an orange task chair, and a curtained window." >}}
+
+{{< figure src="IMG_2047.jpeg"
+  alt="A wider view of the office: the desk with a laptop on a stand, monitors on arms, and a camera on a tripod; a red side table with Phillies caps and a lamp, a Phillie Phanatic plush on the chair, and a Peanuts cartoon on the TV." >}}
+
+{{< figure src="IMG_2048.jpeg"
+  alt="Another angle of the office showing the dual-monitor desk, a bright floor lamp, a corkboard and December calendar on the wall, and stuffed toys in the corner." >}}
+
+{{< figure src="IMG_2049.jpeg"
+  alt="A selfie of me smiling in the freshly set-up office, with the desk, monitors, and stairs visible behind me." >}}
 
 On Monday I am scheduled to take delivery of a new bookcase for the office. In the new year I'm also planning to look into some alternative lighting, better cable management, more wall art, and maybe a motorized standing desk.
 

--- a/content/posts/2022/2/moms-passing/index.md
+++ b/content/posts/2022/2/moms-passing/index.md
@@ -16,9 +16,7 @@ I look forward to connecting with everyone again after I take some time to get t
 
 ---
 
-<figure style="width: 30%; margin: 0;">
-<img src="mom.jpg" alt="Photo of Maureen L. Carney" data-action="zoom">
-</figure>
+{{< figure src="mom.jpg" width="30%" alt="Photo of Maureen L. Carney" >}}
 
 Maureen L. Carney (nee Heffernan)
 

--- a/content/posts/2022/3/quantum-jira/index.md
+++ b/content/posts/2022/3/quantum-jira/index.md
@@ -10,9 +10,7 @@ series:
 
 Random crossover that occurred to me during a morning walk.
 
-<figure style="width: 70%; margin: 0 auto;">
-<img src="logo.png" alt="Quantum JIRA Logo" data-action="zoom">
-</figure>
+{{< figure src="logo.png" width="70%" alt="Quantum JIRA Logo" >}}
 
 Theorizing that one could be productive within his own lifetime, Doctor Mike Zornek stepped into the Quantum JIRA accelerator - and vanished. He awoke to find himself trapped in tech of the past, facing repos origins that were not his own, and driven by an unknown force to change commit history for the better. His only guide on this journey is Al, an overworked product manager, who appears in the form of a Slack avatar only Mike can see and hear.
 

--- a/content/posts/2022/7/baseball-hall-of-fame/index.md
+++ b/content/posts/2022/7/baseball-hall-of-fame/index.md
@@ -46,25 +46,55 @@ The Hall of Fame is spread across three floors. You start with exhibits on the s
 
 I took a few photos, mostly of Phillies stuff that caught my eye or other players I am fond of. My goal with photos of museums like this is not high quality per se but to capture a few visuals to help me recall the trip and the feeling of the place. The goal here is NOT to fully document the place; how can one even try.
 
-![](IMG_1573.jpeg)
-![](IMG_1597.jpeg)
-![](IMG_1605.jpeg)
-![](IMG_1607.jpeg)
-![](IMG_1610.jpeg)
-![](IMG_1616.jpeg)
-![](IMG_1617.jpeg)
-![](IMG_1620.jpeg)
-![](IMG_1622.jpeg)
-![](IMG_1623.jpeg)
-![](IMG_1665.jpeg)
-![](IMG_1644.jpeg)
-![](IMG_1631.jpeg)
-![](IMG_1636.jpeg)
-![](IMG_1646.jpeg)
-![](IMG_1650.jpeg)
-![](IMG_1651.jpeg)
-![](IMG_1658.jpeg)
-![](IMG_1664.jpeg)
+{{< figure src="IMG_1573.jpeg"  alt="A museum wall display honoring the 1950 Phillies \"Whiz Kids,\" with black-and-white player photos, a team photo, and a Phillies jersey and cap in a glass case." >}}
+
+{{< figure src="IMG_1597.jpeg"  alt="Greg Maddux's Chicago Cubs cap on display beside a card marking his 355 career wins, with rows of baseballs behind it." >}}
+
+{{< figure src="IMG_1605.jpeg"
+  alt="A placard describing the jersey Roy Halladay wore for his no-hitter in Game One of the 2010 Phillies-Reds NLDS." >}}
+
+{{< figure src="IMG_1607.jpeg"
+  alt="A Phillies 2008 World Series championship ring on black velvet among other teams' championship rings labeled by year." >}}
+
+{{< figure src="IMG_1610.jpeg"  alt="Brad Lidge's red Phillies cap from the 2008 World Series in a display case, with a card noting his perfect season of 48 saves." >}}
+
+{{< figure src="IMG_1616.jpeg"
+  alt="A locker-style case of red Phillies caps, a jersey, and a baseball, beside a Phillies panel listing the team's retired numbers." >}}
+
+{{< figure src="IMG_1617.jpeg"
+  alt="Phillies memorabilia in a locker case: Cole Hamels' and Cliff Lee's caps, a perfect-game ball, and a pinstriped Phillies jersey." >}}
+
+{{< figure src="IMG_1620.jpeg"
+  alt="Ryan Howard's Phillies cap displayed above his and Joe Blanton's bats from the 2008 World Series, with descriptive placards." >}}
+
+{{< figure src="IMG_1622.jpeg"
+  alt="Aaron Rowand's well-worn tan Rawlings fielding glove on display with a placard." >}}
+
+{{< figure src="IMG_1623.jpeg"
+  alt="Jamie Moyer's black glove, embroidered with his name, beside a placard noting he became the majors' oldest pitcher to win a game, at age 49." >}}
+
+{{< figure src="IMG_1665.jpeg"
+  alt="A museum panel honoring Phillies broadcaster Harry Kalas with his photo and career summary; below it, a broadcaster's quote reads \"Juuust a bit outside.\"" >}}
+
+{{< figure src="IMG_1644.jpeg"
+  alt="The marble-columned entrance to the Hall of Fame plaque gallery, visitors passing through an arched doorway; a young man sits on a bench in the foreground." >}}
+
+{{< figure src="IMG_1631.jpeg"  alt="Connie Mack's bronze Hall of Fame plaque, honoring the longtime Philadelphia Athletics manager." >}}
+
+{{< figure src="IMG_1636.jpeg"  alt="Jackie Robinson's bronze Hall of Fame plaque." >}}
+
+{{< figure src="IMG_1646.jpeg"  alt="Satchel Paige's bronze Hall of Fame plaque, noting his years in the Negro Leagues and the majors." >}}
+
+{{< figure src="IMG_1650.jpeg"
+  alt="Mike Schmidt's bronze Hall of Fame plaque, photographed at an angle." >}}
+
+{{< figure src="IMG_1651.jpeg"
+  alt="Richie Ashburn's bronze Hall of Fame plaque, photographed at an angle." >}}
+
+{{< figure src="IMG_1658.jpeg"  alt="Tom Glavine's bronze Hall of Fame plaque." >}}
+
+{{< figure src="IMG_1664.jpeg"
+  alt="A corner of the plaque gallery: rows of bronze inductee plaques on wood paneling beside blank silver plaques awaiting future inductees." >}}
 
 The Hall of Fame was very enjoyable. Visiting it alongside my rewatching of the Ken Burns Baseball documentary (which I've been working through over the past few weeks) put me in an excellent mindset to appreciate everything I was looking at. Lots of cool memorabilia and some great pull quotes/stories shared. I like those more than the raw statistics, still appreciating how numbers help one compare the play style and successes of one player vs. another.
 
@@ -82,9 +112,14 @@ I wanted a little mini bat souvenir, and there are a few bat store options in to
 
 Also, let us have some empathy for the poor souls running the Hall of Fame gift shop.
 
-![](no-fun-1.jpeg)
-![](no-fun-2.jpeg)
-![](no-fun-3.jpeg)
+{{< figure src="no-fun-1.jpeg"
+  alt="A rack of wooden souvenir bats in the gift shop, with a sign reading \"Please DO NOT Swing Bats in Store.\"" >}}
+
+{{< figure src="no-fun-2.jpeg"
+  alt="Bins of souvenir baseballs in the gift shop, with a sign reading \"Please Do Not Bounce the Balls in the Store.\"" >}}
+
+{{< figure src="no-fun-3.jpeg"
+  alt="A shelf of player bobbleheads in the gift shop, with a sign reading \"Please DO NOT Touch the Bobbleheads!\"" >}}
 
 I ended the afternoon with a small scoop of peanut butter and chocolate ice cream and then headed back to the inn. There I relaxed a bit. I enjoyed some hard iced tea drinks and read [a Phillies book](https://twitter.com/zorn/status/1549896657512407040) I brought with me on the inn's patio. Around dinner time, I walked over to a nearby pizza place. The pizza was "NY style" with a thinker crust. Not my preference, but it was pretty good. Back at the inn, I rested in my air-conditioned room. Was happy to discover Moneyball playing on TV and watched it.
 

--- a/content/posts/2022/8/12-journal/index.md
+++ b/content/posts/2022/8/12-journal/index.md
@@ -16,17 +16,22 @@ My sister and her friend like to go to the beach later and stay late. We had som
 
 We had a very bright moon, and the colors that came out at the end of the day were notably pretty.
 
-![](IMG_3805.jpeg)
+{{< figure src="IMG_3805.jpeg"
+  alt="Dusk beach scene: pale crepuscular rays fan up from the horizon across a deep blue sky, the full moon low at right, waves rolling onto the sand." >}}
 
-![](IMG_3807.jpeg)
+{{< figure src="IMG_3807.jpeg"
+  alt="A wide beach at twilight, wet sand mirroring a pastel sky, a few people and shorebirds near the waterline, an amusement-pier roller coaster silhouetted in the distance." >}}
 
-![](IMG_3808.jpeg)
+{{< figure src="IMG_3808.jpeg"
+  alt="Twilight over the ocean, the deep blue sky streaked with crepuscular rays, the full moon glowing, a lone figure small on the sand at right." >}}
 
 To be clear, this is the moon, not the sun. The day is over--we are headed home.
 
-![](IMG_3816.jpeg)
+{{< figure src="IMG_3816.jpeg"
+  alt="The full moon high in a deep blue evening sky, its light reflecting in a long shimmer across the ocean and wet sand." >}}
 
-![](IMG_3821.jpeg)
+{{< figure src="IMG_3821.jpeg"
+  alt="My sister Michelle Dunster and I walk across the moonlit beach pulling a beach cart, me waving to the camera, the full moon glowing above the water behind us." >}}
 
 When I returned to the city Wednesday night, I caught up on random emails and hosted the Philly Elixir meetup.
 

--- a/content/posts/2022/9/26-liveview-native/index.md
+++ b/content/posts/2022/9/26-liveview-native/index.md
@@ -45,11 +45,8 @@ It's a unique take on the problem that unlocks potentially impressive solutions,
 
 I've been working with Elixir since 2017 and LiveView since it was announced in 2019. Before Elixir, I spent more than a decade doing Apple platform development, first on the Mac and then on the iPhone. By the end, I was teaching iOS programming classes at places like Amazon and Google via my job at Big Nerd Ranch. So when this announcement came out, I felt like worlds were colliding and said as much.
 
-<figure style="width: 70%; margin: 0 auto;">
-<a href="https://twitter.com/zorn/status/1565370172311060482">
-  <img src="worlds-colliding.png" alt="A tweet from me (@zorn) pairing a conference slide titled 'What is LiveView Native?' with the Seinfeld meme of George Costanza, captioned 'Worlds are colliding.'" data-action="zoom">
-</a>
-</figure>
+{{< figure src="worlds-colliding.png" width="70%" link="https://twitter.com/zorn/status/1565370172311060482"
+  alt="A tweet from me (@zorn) pairing a conference slide titled 'What is LiveView Native?' with the Seinfeld meme of George Costanza, captioned 'Worlds are colliding.'" >}}
 
 I have many historic pessimistic opinions on multi-platform frameworks that try to sell "write once, deploy everywhere." I'll get into some of those later, but first, I'll share my tutorial observations.
 
@@ -59,21 +56,15 @@ During the first half of Side Project Saturday, I worked through the [Your First
 
 In the Phoenix project, you build a `CatsListLive` live view with SwiftUI-specific `heex` template content.
 
-<figure style="width: 90%; margin: 0 auto;">
-<a href="swiftui-in-heex.png">
-  <img src="swiftui-in-heex.png" alt="A code editor showing an Elixir LiveView module beside a .heex template that contains SwiftUI-style elements like NavigationLink, HStack, AsyncImage, and a star Button.">
-</a>
-</figure>
+{{< figure src="swiftui-in-heex.png" width="90%"
+  alt="A code editor showing an Elixir LiveView module beside a .heex template that contains SwiftUI-style elements like NavigationLink, HStack, AsyncImage, and a star Button." >}}
 
 In the iOS project, you'll add some of the LiveView Native package dependencies and then configure the default `ContentView` to load the swifty `LiveView` view class, which points at a `localhost:4000` URI via configuration.
 
 When you launch the iOS app, the `LiveView` view class inside of SwiftUI will connect to the Phoenix server, which makes a live view server process for `CatsListLive` and then sends down the template. When received inside of iOS, the view hierarchy is injected, and then regular old SwiftUI will render it just as if it had complied typically.
 
-<figure style="width: 90%; margin: 0 auto;">
-<a href="xcode.png">
-  <img src="xcode.png" alt="Xcode running the LiveView Native cats demo: SwiftUI code on the left and an iPhone simulator on the right showing a scrollable list of cats with photos and favorite-star buttons.">
-</a>
-</figure>
+{{< figure src="xcode.png" width="90%"
+  alt="Xcode running the LiveView Native cats demo: SwiftUI code on the left and an iPhone simulator on the right showing a scrollable list of cats with photos and favorite-star buttons." >}}
 
 You may notice that the SwiftUI code templated in `heex` has things like `phx-click="toggle-favorite"`. When the button is "clicked" in the iOS app, the event is sent via the websocket to the live view process on the server, the state is updated per standard LiveView lifecycle mechanics, and then the template is re-rendered, and diffs are applied.
 
@@ -87,11 +78,8 @@ However, this tool is not really built for them. So who is this being built for?
 
 # What pain is LiveView Native is trying to solve?
 
-<figure style="width: 70%; margin: 0 auto;">
-<a href="hot-take.jpg">
-  <img src="hot-take.jpg" alt="A glowing roadside marquee at dusk reading 'Hot Take House,' with a neon 'Open 24 Hours' sign below.">
-</a>
-</figure>
+{{< figure src="hot-take.jpg" width="70%"
+  alt="A glowing roadside marquee at dusk reading 'Hot Take House,' with a neon 'Open 24 Hours' sign below." >}}
 
 The [marketing site](https://native.live) for the project states:
 
@@ -112,11 +100,8 @@ I'll also add that I have many friends already working in SwiftUI natively in Xc
 
 ## Will Apple approve this?
 
-<figure style="width: 40%; margin: 0 auto;">
-<a href="app-store.jpg">
-  <img src="app-store.jpg" alt="The 'Henry Cavill strolling while Jason Momoa sneaks up behind' meme: Cavill, labeled 'LiveView developers,' walks calmly while a grinning Momoa, labeled 'the chaos of App Store reviews,' creeps up behind him.">
-</a>
-</figure>
+{{< figure src="app-store.jpg" width="40%"
+  alt="The 'Henry Cavill strolling while Jason Momoa sneaks up behind' meme: Cavill, labeled 'LiveView developers,' walks calmly while a grinning Momoa, labeled 'the chaos of App Store reviews,' creeps up behind him." >}}
 
 I hate app store review and distribution exclusivity. It was one of the primary reasons why I left the platform years ago.
 

--- a/content/posts/2022/9/26-liveview-native/index.md
+++ b/content/posts/2022/9/26-liveview-native/index.md
@@ -47,7 +47,7 @@ I've been working with Elixir since 2017 and LiveView since it was announced in 
 
 <figure style="width: 70%; margin: 0 auto;">
 <a href="https://twitter.com/zorn/status/1565370172311060482">
-  <img src="worlds-colliding.png" alt="Worlds Colliding Tweet" data-action="zoom">
+  <img src="worlds-colliding.png" alt="A tweet from me (@zorn) pairing a conference slide titled 'What is LiveView Native?' with the Seinfeld meme of George Costanza, captioned 'Worlds are colliding.'" data-action="zoom">
 </a>
 </figure>
 
@@ -61,7 +61,7 @@ In the Phoenix project, you build a `CatsListLive` live view with SwiftUI-specif
 
 <figure style="width: 90%; margin: 0 auto;">
 <a href="swiftui-in-heex.png">
-  <img src="swiftui-in-heex.png" alt="LiveView with SwiftUI inside a `heex` template.">
+  <img src="swiftui-in-heex.png" alt="A code editor showing an Elixir LiveView module beside a .heex template that contains SwiftUI-style elements like NavigationLink, HStack, AsyncImage, and a star Button.">
 </a>
 </figure>
 
@@ -71,7 +71,7 @@ When you launch the iOS app, the `LiveView` view class inside of SwiftUI will co
 
 <figure style="width: 90%; margin: 0 auto;">
 <a href="xcode.png">
-  <img src="xcode.png" alt="The Cats Demo in Xcode">
+  <img src="xcode.png" alt="Xcode running the LiveView Native cats demo: SwiftUI code on the left and an iPhone simulator on the right showing a scrollable list of cats with photos and favorite-star buttons.">
 </a>
 </figure>
 
@@ -89,7 +89,7 @@ However, this tool is not really built for them. So who is this being built for?
 
 <figure style="width: 70%; margin: 0 auto;">
 <a href="hot-take.jpg">
-  <img src="hot-take.jpg" alt="Hot Take House">
+  <img src="hot-take.jpg" alt="A glowing roadside marquee at dusk reading 'Hot Take House,' with a neon 'Open 24 Hours' sign below.">
 </a>
 </figure>
 
@@ -114,7 +114,7 @@ I'll also add that I have many friends already working in SwiftUI natively in Xc
 
 <figure style="width: 40%; margin: 0 auto;">
 <a href="app-store.jpg">
-  <img src="app-store.jpg" alt="App Store Review meme">
+  <img src="app-store.jpg" alt="The 'Henry Cavill strolling while Jason Momoa sneaks up behind' meme: Cavill, labeled 'LiveView developers,' walks calmly while a grinning Momoa, labeled 'the chaos of App Store reviews,' creeps up behind him.">
 </a>
 </figure>
 

--- a/content/posts/2023/4/technical-debt/index.md
+++ b/content/posts/2023/4/technical-debt/index.md
@@ -36,10 +36,9 @@ What the book **does not** get into is the discussions around getting time alloc
 
 ## Selling
 
-<figure style="width: 50%; margin: 0 auto;">
-<img src= "tech-debt-meme.jpg" alt= "Construction worker in front of a very broken house being asked why it takes so long to add a new window." data-action=" zoom"/>
-<figcaption>Technical Debt Meme</figcaption>
-</figure>
+{{< figure src="tech-debt-meme.jpg" width="50%"
+  caption="Technical Debt Meme"
+  alt="Construction worker in front of a very broken house being asked why it takes so long to add a new window." >}}
 
 Saw this meme over the weekend, and it's a good discussion starting point for the common perspective challenges of technical debt.
 

--- a/content/posts/2024/12/new-gaming-pc/index.md
+++ b/content/posts/2024/12/new-gaming-pc/index.md
@@ -11,19 +11,11 @@ tags:
 
 In the closing days of summer this past year, I started to get an itch about building a new gaming PC. In this post, I'll share what I built and some notes on its assembly.
 
-<figure>
-<a href="computer.jpeg">
-<img src="computer.jpeg" alt="Assembled computer powered off.">
-</a>
-<figcaption>Assembled computer powered off.</figcaption>
-</figure>
+{{< figure src="computer.jpeg" alt="Assembled computer powered off." >}}
 
-<figure>
-<a href="colors.jpeg">
-<img src="colors.jpeg" alt="The assembled white PC tower powered on, its glass panels glowing with blue and purple RGB light from the fans and light strips. Inside are a white air cooler, a GeForce RTX graphics card, and three side fans with small circular LCD screens showing temperatures (47C, 42C) and load (9%).">
-</a>
-<figcaption>Assembled computer powered on.</figcaption>
-</figure>
+{{< figure src="colors.jpeg"
+  caption="Assembled computer powered on."
+  alt="The assembled white PC tower powered on, its glass panels glowing with blue and purple RGB light from the fans and light strips. Inside are a white air cooler, a GeForce RTX graphics card, and three side fans with small circular LCD screens showing temperatures (47C, 42C) and load (9%)." >}}
 
 ## Inspiration
 
@@ -37,12 +29,7 @@ In recent years, I shelved the gaming PC and have, instead, enjoyed my game time
 
 [PC Parts list.](https://pcpartpicker.com/list/zCygTY)
 
-<figure>
-<a href="parts.jpeg">
-<img src="parts.jpeg" alt="Various PC parts laid out for assembly.">
-</a>
-<figcaption>Various PC parts laid out for assembly.</figcaption>
-</figure>
+{{< figure src="parts.jpeg" alt="Various PC parts laid out for assembly." >}}
 
 For this build, I wanted to lean more toward a visual presentation. My last build was very economical, a traditional black tower with no real frills. It would be fun to give this some personality. It's a white build with some limited RGB lighting that would lean towards a purple hue.
 
@@ -78,20 +65,14 @@ If I were doing this again, I might suggest buying a test bench setup or otherwi
 
 After I got the computer to POST, one issue I did run into was fans. I misunderstood the wide range of fan models Lian Li was selling and ended up buying a mix of fans and controllers that were not fully compatible. I made a midday MicroCenter run to buy compatible alternatives and had to reinstall them a few times to get it all worked out. Ultimately, I had to install two separate fan controllers (one for the LCD fans and another for the simple RGB fans).
 
-<figure>
-<a href="desk.jpeg">
-<img src="desk.jpeg" alt="The full desk shot.">
-</a>
-<figcaption>The full desk shot.</figcaption>
-</figure>
+{{< figure src="desk.jpeg" alt="The full desk shot." >}}
 
 ## Windows
 
 Not having a readily available Windows computer around, I followed some [instructions](https://windowsreport.com/windows-11-usb-installer-on-mac/) to download the Windows 11 installer and make a bootable USB drive from my Mac. This worked fine for me, though sadly, I did not get a working network driver for the motherboard's wifi chip from Windows, so I had to download some manual drivers onto a separate USB drive to get that working. Once I was on the wifi, I could get all the other drivers directly from this machine, as well as the many OS-level updates.
 
-<figure>
-<img src="second-updates.png" alt="A Lord of the Rings meme about Windows updates. Merry and Pippin: 'We have some updates for you, PC.' Aragorn: 'We already had it.' Pippin: 'We've had one, yes. What about second updates?'">
-</figure>
+{{< figure src="second-updates.png" link="false"
+  alt="A Lord of the Rings meme about Windows updates. Merry and Pippin: 'We have some updates for you, PC.' Aragorn: 'We already had it.' Pippin: 'We've had one, yes. What about second updates?'" >}}
 
 I had a Windows 10 license from my old gaming PC, which worked fine for registering this copy of Windows 11.
 

--- a/content/posts/2024/12/new-gaming-pc/index.md
+++ b/content/posts/2024/12/new-gaming-pc/index.md
@@ -20,7 +20,7 @@ In the closing days of summer this past year, I started to get an itch about bui
 
 <figure>
 <a href="colors.jpeg">
-<img src="colors.jpeg" alt="Assembled computer powered on.">
+<img src="colors.jpeg" alt="The assembled white PC tower powered on, its glass panels glowing with blue and purple RGB light from the fans and light strips. Inside are a white air cooler, a GeForce RTX graphics card, and three side fans with small circular LCD screens showing temperatures (47C, 42C) and load (9%).">
 </a>
 <figcaption>Assembled computer powered on.</figcaption>
 </figure>
@@ -90,7 +90,7 @@ After I got the computer to POST, one issue I did run into was fans. I misunders
 Not having a readily available Windows computer around, I followed some [instructions](https://windowsreport.com/windows-11-usb-installer-on-mac/) to download the Windows 11 installer and make a bootable USB drive from my Mac. This worked fine for me, though sadly, I did not get a working network driver for the motherboard's wifi chip from Windows, so I had to download some manual drivers onto a separate USB drive to get that working. Once I was on the wifi, I could get all the other drivers directly from this machine, as well as the many OS-level updates.
 
 <figure>
-<img src="second-updates.png" alt="A Lord of the Rings meme about Windows updates. Merry and Pippin: We have some updates for you PC. Aragorn: We already had it. Pippin: We've had one yes. WHAT ABOUT SECOND UPDATES">
+<img src="second-updates.png" alt="A Lord of the Rings meme about Windows updates. Merry and Pippin: 'We have some updates for you, PC.' Aragorn: 'We already had it.' Pippin: 'We've had one, yes. What about second updates?'">
 </figure>
 
 I had a Windows 10 license from my old gaming PC, which worked fine for registering this copy of Windows 11.

--- a/content/posts/2025/1/a-few-good-memes/index.md
+++ b/content/posts/2025/1/a-few-good-memes/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 
 <figure>
-<img src="code-reviews-too-harsh.png" alt="A scene from the movie A Few Good Men. Base Commander Colonel Nathan Jessep is on the stand. The meme reads: CODE REVIEWS TOO HARSH? / YOU WANT ME ON THAT WALL, YOU NEED ME ON THAT WALL." data-action="zoom">
+<img src="code-reviews-too-harsh.png" alt="A scene from the movie A Few Good Men. Base Commander Colonel Nathan Jessep is on the stand. The meme reads: 'Code reviews too harsh? You want me on that wall, you need me on that wall.'" data-action="zoom">
 </figure>
 
 Yesterday I took to `r/ProgrammerHumor` to reply to [this post about code review](https://www.reddit.com/r/ProgrammerHumor/comments/1ib4ifc/titleisdealingwithatoxicsenior/). I used a meme I [crafted back in September](https://jawns.club/@zorn/113194431261362116) and posted this meme as I was preparing for quarterly performance review season. It since has gotten some replies that have me laughing out loud. Recording for prosperity.

--- a/content/posts/2025/1/a-few-good-memes/index.md
+++ b/content/posts/2025/1/a-few-good-memes/index.md
@@ -8,9 +8,8 @@ tags:
   - software-craft
 ---
 
-<figure>
-<img src="code-reviews-too-harsh.png" alt="A scene from the movie A Few Good Men. Base Commander Colonel Nathan Jessep is on the stand. The meme reads: 'Code reviews too harsh? You want me on that wall, you need me on that wall.'" data-action="zoom">
-</figure>
+{{< figure src="code-reviews-too-harsh.png"
+  alt="A scene from the movie A Few Good Men. Base Commander Colonel Nathan Jessep is on the stand. The meme reads: 'Code reviews too harsh? You want me on that wall, you need me on that wall.'" >}}
 
 Yesterday I took to `r/ProgrammerHumor` to reply to [this post about code review](https://www.reddit.com/r/ProgrammerHumor/comments/1ib4ifc/titleisdealingwithatoxicsenior/). I used a meme I [crafted back in September](https://jawns.club/@zorn/113194431261362116) and posted this meme as I was preparing for quarterly performance review season. It since has gotten some replies that have me laughing out loud. Recording for prosperity.
 

--- a/content/posts/2025/5/returning-to-self-employment/index.md
+++ b/content/posts/2025/5/returning-to-self-employment/index.md
@@ -10,9 +10,8 @@ tags:
 
 My full-time employment is coming to a close, and I am once again rebooting my self-employment life.
 
-<figure>
-<img src="freedom.jpeg" alt="Mike Zornek holds a framed comic strip titled 'New Life' by Alex Norris. The comic has three panels. In the first panel, a pink character escapes from a brick box labeled 'Employment,' saying, 'I will escape the confines of this box.' In the second panel, the character floats free and says, 'So I am free to decide my own projects & schedule.' In the third panel, the character is now inside a nearly identical brick box labeled 'Freelance' and says, 'oh no.' Mike Zornek is partially visible, with his eyes peeking over the top of the frame." data-action="zoom">
-</figure>
+{{< figure src="freedom.jpeg"
+  alt="Mike Zornek holds a framed comic strip titled 'New Life' by Alex Norris. The comic has three panels. In the first panel, a pink character escapes from a brick box labeled 'Employment,' saying, 'I will escape the confines of this box.' In the second panel, the character floats free and says, 'So I am free to decide my own projects & schedule.' In the third panel, the character is now inside a nearly identical brick box labeled 'Freelance' and says, 'oh no.' Mike Zornek is partially visible, with his eyes peeking over the top of the frame." >}}
 
 From [web comic name](https://webcomicname.com/).
 

--- a/content/posts/2026/7/inherited-software-checklist/index.md
+++ b/content/posts/2026/7/inherited-software-checklist/index.md
@@ -13,12 +13,12 @@ Not every [consulting engagement](/elixir-consulting/) starts with joining a tea
 
 The goal in week one on these projects isn't to improve anything. It's narrower than that: get to a place where you can react safely if something breaks. Everything below is in service of that one goal.
 
-<figure style="max-width: 20rem; margin-inline: auto;">
-<a href="orly-previous-developers-long-gone.png">
-<img src="orly-previous-developers-long-gone.png" alt="A parody O'Reilly book cover with a woodcut illustration of a cow. The header reads 'Some assembly required. Instructions not included.' The title is 'The Previous Developers are Long Gone' with the subtitle 'This is our problem now.' Signed Mike Zornek." style="border: 1px solid #ddd;">
-</a>
-<figcaption>The Previous Developers are Long Gone: This is our problem now.</figcaption>
-</figure>
+{{< figure
+  src="orly-previous-developers-long-gone.png"
+  width="20rem"
+  alt="A parody O'Reilly book cover with a woodcut illustration of a cow. The header reads 'Some assembly required. Instructions not included.' The title is 'The Previous Developers are Long Gone' with the subtitle 'This is our problem now.' Signed Mike Zornek."
+  caption="The Previous Developers are Long Gone: This is our problem now."
+>}}
 
 ## Get the app running locally
 

--- a/content/projects/philly-cocoaheads/_index.md
+++ b/content/projects/philly-cocoaheads/_index.md
@@ -6,13 +6,9 @@ layout: onepage
 
 ## Philly CocoaHeads Website (Hugo)
 
-<div class="screenshots">
+{{< figure src="pc-home.png" alt="The Philly CocoaHeads home page, a clean single-column layout introducing the group and its upcoming meetups." >}}
 
-<a href="pc-home.png"><img src="pc-home.png" alt="Philly CocoaHeads Home Page"></a>
-
-<a href="pc-about.png"><img src="pc-about.png" alt="Philly CocoaHeads About Page"></a>
-
-</div>
+{{< figure src="pc-about.png" alt="The Philly CocoaHeads about page, describing the group's history and what to expect at a meeting." >}}
 
 Project Goals:
 

--- a/themes/reborn/layouts/_default/baseof.html
+++ b/themes/reborn/layouts/_default/baseof.html
@@ -19,7 +19,7 @@
     {{ if hugo.IsServer }}
       {{/* Dev-only alt-text overlay for accessibility review. Guarded by
         hugo.IsServer so it only runs under `hugo server` and never ships to
-        production. Remove once the alt-text review pass is complete.
+        production.
       */}}
       <script>
         document.querySelectorAll("main img[alt]").forEach((img) => {

--- a/themes/reborn/layouts/_default/baseof.html
+++ b/themes/reborn/layouts/_default/baseof.html
@@ -16,5 +16,19 @@
     {{ partial "header.html" . }}
     {{ block "main" . }}{{ end }}
     {{ partial "footer.html" . }}
+    {{ if hugo.IsServer }}
+      {{/* Dev-only alt-text overlay for accessibility review. Guarded by
+           hugo.IsServer so it only runs under `hugo server` and never ships to
+           production. Remove once the alt-text review pass is complete. */}}
+      <script>
+        document.querySelectorAll("main img[alt]").forEach((img) => {
+          const tag = document.createElement("div");
+          tag.textContent = "ALT: " + img.getAttribute("alt");
+          tag.style.cssText =
+            "font:12px/1.4 monospace;background:#ffc;color:#000;border:1px solid #e0c000;padding:4px 6px;margin:4px 0;white-space:pre-wrap;";
+          (img.closest("figure") || img).insertAdjacentElement("afterend", tag);
+        });
+      </script>
+    {{ end }}
   </body>
 </html>

--- a/themes/reborn/layouts/_default/baseof.html
+++ b/themes/reborn/layouts/_default/baseof.html
@@ -18,11 +18,13 @@
     {{ partial "footer.html" . }}
     {{ if hugo.IsServer }}
       {{/* Dev-only alt-text overlay for accessibility review. Guarded by
-           hugo.IsServer so it only runs under `hugo server` and never ships to
-           production. Remove once the alt-text review pass is complete. */}}
+        hugo.IsServer so it only runs under `hugo server` and never ships to
+        production. Remove once the alt-text review pass is complete.
+      */}}
       <script>
         document.querySelectorAll("main img[alt]").forEach((img) => {
           const tag = document.createElement("div");
+          tag.setAttribute("aria-hidden", "true");
           tag.textContent = "ALT: " + img.getAttribute("alt");
           tag.style.cssText =
             "font:12px/1.4 monospace;background:#ffc;color:#000;border:1px solid #e0c000;padding:4px 6px;margin:4px 0;white-space:pre-wrap;";

--- a/themes/reborn/layouts/_markup/render-image.html
+++ b/themes/reborn/layouts/_markup/render-image.html
@@ -1,0 +1,37 @@
+{{- /*
+  Image render hook.
+
+  Motivation (see issue #90): markdown images written with a bare, bundle-relative
+  filename — e.g. `![Alt](main-stage.jpeg)` — render as a relative <img src>. A
+  relative src resolves against the URL in the address bar, so it only loads when
+  the visitor is on the canonical trailing-slash URL (`/posts/.../slug/`). Land on
+  the same page without the slash and every local image 404s.
+
+  This hook resolves such images as page resources and emits an absolute
+  RelPermalink, removing the trailing-slash dependency. It also adds lazy loading
+  and intrinsic width/height (which helps CLS / the Lighthouse budget). Remote and
+  already-absolute (`/...`) sources are passed through untouched.
+*/ -}}
+{{- $dest := .Destination -}}
+{{- $u := urls.Parse $dest -}}
+{{- $src := $dest -}}
+{{- $width := "" -}}
+{{- $height := "" -}}
+{{- if and (not $u.IsAbs) (not (strings.HasPrefix $dest "/")) -}}
+  {{- with .Page.Resources.GetMatch $dest -}}
+    {{- $src = .RelPermalink -}}
+    {{- if eq .MediaType.MainType "image" -}}
+      {{- if and (ne .MediaType.SubType "svg") (ne .MediaType.SubType "gif") -}}
+        {{- $width = .Width -}}
+        {{- $height = .Height -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- warnf "render-image: no resource found for %q on page %q" $dest .Page.Path -}}
+  {{- end -}}
+{{- end -}}
+<img src="{{ $src }}" alt="{{ .PlainText }}"
+  {{- with .Title }} title="{{ . }}"{{ end }}
+  {{- with $width }} width="{{ . }}"{{ end }}
+  {{- with $height }} height="{{ . }}"{{ end }}
+  loading="lazy" decoding="async">

--- a/themes/reborn/layouts/_markup/render-image.html
+++ b/themes/reborn/layouts/_markup/render-image.html
@@ -41,6 +41,9 @@
     {{- warnf "render-image: no resource found for %q on page %q" $dest .Page.Path -}}
   {{- end -}}
 {{- end -}}
+{{- if not (trim .PlainText " ") -}}
+  {{- warnf "render-image: missing alt text for image %q on page %q" $dest .Page.Path -}}
+{{- end -}}
 <img src="{{ $src }}" alt="{{ .PlainText }}"
   {{- with .Title }} title="{{ . }}"{{ end }}
   {{- with $width }} width="{{ . }}"{{ end }}

--- a/themes/reborn/layouts/_markup/render-image.html
+++ b/themes/reborn/layouts/_markup/render-image.html
@@ -41,12 +41,8 @@
     {{- warnf "render-image: no resource found for %q on page %q" $dest .Page.Path -}}
   {{- end -}}
 {{- end -}}
-<img
-  src="{{ $src }}"
-  alt="{{ .PlainText }}"
-  {{- with .Title }}title="{{ . }}"{{ end }}
-  {{- with $width }}width="{{ . }}"{{ end }}
-  {{- with $height }}height="{{ . }}"{{ end }}
-  loading="lazy"
-  decoding="async"
->
+<img src="{{ $src }}" alt="{{ .PlainText }}"
+  {{- with .Title }} title="{{ . }}"{{ end }}
+  {{- with $width }} width="{{ . }}"{{ end }}
+  {{- with $height }} height="{{ . }}"{{ end }}
+  loading="lazy" decoding="async">

--- a/themes/reborn/layouts/_markup/render-image.html
+++ b/themes/reborn/layouts/_markup/render-image.html
@@ -7,11 +7,12 @@
   the visitor is on the canonical trailing-slash URL (`/posts/.../slug/`). Land on
   the same page without the slash and every local image 404s.
 
-  This hook resolves such images as page resources and emits an absolute
+  This hook resolves such images as page resources and emits a root-relative
   RelPermalink, removing the trailing-slash dependency. It also adds lazy loading
   and intrinsic width/height (which helps CLS / the Lighthouse budget). Remote and
   already-absolute (`/...`) sources are passed through untouched.
-*/ -}}
+  */
+-}}
 {{- $dest := .Destination -}}
 {{- $u := urls.Parse $dest -}}
 {{- $src := $dest -}}
@@ -24,14 +25,28 @@
       {{- if and (ne .MediaType.SubType "svg") (ne .MediaType.SubType "gif") -}}
         {{- $width = .Width -}}
         {{- $height = .Height -}}
+        {{/* Correct for EXIF orientation, matching the figure shortcode: Hugo's
+          .Width/.Height ignore the orientation flag that browsers honor, so
+          for images rotated 90 degrees (orientation 5-8) the raw pixels are
+          landscape while the render is portrait. Swap the emitted dimensions
+          to keep the intrinsic aspect ratio correct (no layout shift).
+        */}}
+        {{- if in (slice 5 6 7 8) .Meta.Orientation -}}
+          {{- $width = .Height -}}
+          {{- $height = .Width -}}
+        {{- end -}}
       {{- end -}}
     {{- end -}}
   {{- else -}}
     {{- warnf "render-image: no resource found for %q on page %q" $dest .Page.Path -}}
   {{- end -}}
 {{- end -}}
-<img src="{{ $src }}" alt="{{ .PlainText }}"
-  {{- with .Title }} title="{{ . }}"{{ end }}
-  {{- with $width }} width="{{ . }}"{{ end }}
-  {{- with $height }} height="{{ . }}"{{ end }}
-  loading="lazy" decoding="async">
+<img
+  src="{{ $src }}"
+  alt="{{ .PlainText }}"
+  {{- with .Title }}title="{{ . }}"{{ end }}
+  {{- with $width }}width="{{ . }}"{{ end }}
+  {{- with $height }}height="{{ . }}"{{ end }}
+  loading="lazy"
+  decoding="async"
+>

--- a/themes/reborn/layouts/shortcodes/figure.html
+++ b/themes/reborn/layouts/shortcodes/figure.html
@@ -11,8 +11,10 @@
                merely repeats the alt text — a caption should add context, not
                restate the description.
   - `width`:   CSS max-width for the figure, e.g. "20rem". Omit for full width.
-  - `link`:    set to "false" to disable the click-through to the full-size
-               image. Defaults to linking.
+  - `link`:    controls the click-through. Omit to link to the image itself
+               (view full size); set "false" for no link; or pass another
+               resource filename or a URL to link there instead (e.g. a
+               separate full-resolution image, or a source tweet).
 
   Example:
     {{< figure src="cover.png" width="20rem"
@@ -23,7 +25,7 @@
 {{- $alt := .Get "alt" -}}
 {{- $caption := .Get "caption" -}}
 {{- $width := .Get "width" -}}
-{{- $link := ne (.Get "link") "false" -}}
+{{- $linkParam := .Get "link" -}}
 {{- $res := "" -}}
 {{- with $src }}{{ $res = $.Page.Resources.GetMatch . }}{{ end -}}
 
@@ -53,14 +55,29 @@
     {{- $w = $res.Height -}}
     {{- $h = $res.Width -}}
   {{- end -}}
+  {{/* Link target: omit to link to the image itself; "false" for none; or an
+       explicit resource filename or URL to link elsewhere (e.g. a full-res
+       image or a source tweet). */}}
+  {{- $href := "" -}}
+  {{- if eq $linkParam "false" -}}
+  {{- else if $linkParam -}}
+    {{- $lu := urls.Parse $linkParam -}}
+    {{- if or $lu.IsAbs (strings.HasPrefix $linkParam "/") -}}
+      {{- $href = $linkParam -}}
+    {{- else -}}
+      {{- with $.Page.Resources.GetMatch $linkParam -}}{{- $href = .RelPermalink -}}{{- else -}}{{- $href = $linkParam -}}{{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $href = $res.RelPermalink -}}
+  {{- end -}}
   <figure{{ with $width }} style="max-width: {{ . }}; margin-inline: auto;"{{ end }}>
-    {{- if $link }}<a href="{{ $res.RelPermalink }}">{{ end -}}
+    {{- with $href }}<a href="{{ . }}">{{ end -}}
     <img src="{{ $res.RelPermalink }}" alt="{{ $alt }}"
       {{- if $isRaster }} width="{{ $w }}" height="{{ $h }}"{{ end }}
       loading="lazy" decoding="async" class="border border-gray-300">
-    {{- if $link }}</a>{{ end -}}
+    {{- with $href }}</a>{{ end -}}
     {{- with $caption }}
-    <figcaption>{{ . }}</figcaption>
+    <figcaption>{{ . | safeHTML }}</figcaption>
     {{- end }}
   </figure>
 {{- end -}}

--- a/themes/reborn/layouts/shortcodes/figure.html
+++ b/themes/reborn/layouts/shortcodes/figure.html
@@ -1,0 +1,66 @@
+{{/* Accessible image figure for an image stored next to this page's index.md.
+
+  Resolves the image as a page resource, so the emitted <img src> is an absolute
+  URL that loads regardless of a trailing slash on the post URL (see issue #90),
+  and carries intrinsic width/height plus lazy loading. Available arguments:
+
+  - `src`:     (required) filename of the adjacent image resource.
+  - `alt`:     (required) alt text. THE BUILD FAILS if this is empty, so an
+               image can never ship without a text alternative.
+  - `caption`: visible <figcaption>. Optional. A build *warning* fires if it
+               merely repeats the alt text — a caption should add context, not
+               restate the description.
+  - `width`:   CSS max-width for the figure, e.g. "20rem". Omit for full width.
+  - `link`:    set to "false" to disable the click-through to the full-size
+               image. Defaults to linking.
+
+  Example:
+    {{< figure src="cover.png" width="20rem"
+       alt="A detailed description of what the image shows."
+       caption="A short supplementary label." >}}
+*/}}
+{{- $src := .Get "src" -}}
+{{- $alt := .Get "alt" -}}
+{{- $caption := .Get "caption" -}}
+{{- $width := .Get "width" -}}
+{{- $link := ne (.Get "link") "false" -}}
+{{- $res := "" -}}
+{{- with $src }}{{ $res = $.Page.Resources.GetMatch . }}{{ end -}}
+
+{{/* Validate first. errorf logs an error and fails the build but does NOT stop
+     template execution, so guard the render behind these checks to avoid a
+     confusing secondary error (and to surface a single, clear message). */}}
+{{- if not $src -}}
+  {{- errorf "figure shortcode on page %q: missing required 'src' parameter" .Page.Path -}}
+{{- else if not $alt -}}
+  {{- errorf "figure shortcode on page %q: image %q is missing required 'alt' text" .Page.Path $src -}}
+{{- else if not $res -}}
+  {{- errorf "figure shortcode on page %q: no image resource matches src=%q" .Page.Path $src -}}
+{{- else -}}
+  {{- if and $caption (eq (lower $alt) (lower $caption)) -}}
+    {{- warnf "figure shortcode on page %q: caption duplicates the alt text for %q; a caption should add context, not repeat the description" .Page.Path $src -}}
+  {{- end -}}
+  {{- $isRaster := and (eq $res.MediaType.MainType "image") (not (in (slice "svg" "gif") $res.MediaType.SubType)) -}}
+  {{/* Hugo's .Width/.Height report raw pixel dimensions and ignore the EXIF
+       orientation flag, but browsers honor it. For images the flag rotates 90
+       degrees (orientation 5-8), the displayed image is portrait while the raw
+       pixels are landscape, so swap the emitted dimensions to match what the
+       browser actually renders. This keeps the intrinsic aspect ratio correct
+       (no layout shift) without ever touching or re-encoding the source file. */}}
+  {{- $w := $res.Width -}}
+  {{- $h := $res.Height -}}
+  {{- if and $isRaster (in (slice 5 6 7 8) $res.Meta.Orientation) -}}
+    {{- $w = $res.Height -}}
+    {{- $h = $res.Width -}}
+  {{- end -}}
+  <figure{{ with $width }} style="max-width: {{ . }}; margin-inline: auto;"{{ end }}>
+    {{- if $link }}<a href="{{ $res.RelPermalink }}">{{ end -}}
+    <img src="{{ $res.RelPermalink }}" alt="{{ $alt }}"
+      {{- if $isRaster }} width="{{ $w }}" height="{{ $h }}"{{ end }}
+      loading="lazy" decoding="async" class="border border-gray-300">
+    {{- if $link }}</a>{{ end -}}
+    {{- with $caption }}
+    <figcaption>{{ . }}</figcaption>
+    {{- end }}
+  </figure>
+{{- end -}}

--- a/themes/reborn/layouts/shortcodes/figure.html
+++ b/themes/reborn/layouts/shortcodes/figure.html
@@ -1,7 +1,8 @@
 {{/* Accessible image figure for an image stored next to this page's index.md.
 
-  Resolves the image as a page resource, so the emitted <img src> is an absolute
-  URL that loads regardless of a trailing slash on the post URL (see issue #90),
+  Resolves the image as a page resource, so the emitted <img src> is a
+  root-relative URL that loads regardless of a trailing slash on the post URL
+  (see issue #90),
   and carries intrinsic width/height plus lazy loading. Available arguments:
 
   - `src`:     (required) filename of the adjacent image resource.
@@ -34,7 +35,7 @@
      confusing secondary error (and to surface a single, clear message). */}}
 {{- if not $src -}}
   {{- errorf "figure shortcode on page %q: missing required 'src' parameter" .Page.Path -}}
-{{- else if not $alt -}}
+{{- else if not (trim $alt " \t\r\n") -}}
   {{- errorf "figure shortcode on page %q: image %q is missing required 'alt' text" .Page.Path $src -}}
 {{- else if not $res -}}
   {{- errorf "figure shortcode on page %q: no image resource matches src=%q" .Page.Path $src -}}
@@ -65,7 +66,15 @@
     {{- if or $lu.IsAbs (strings.HasPrefix $linkParam "/") -}}
       {{- $href = $linkParam -}}
     {{- else -}}
-      {{- with $.Page.Resources.GetMatch $linkParam -}}{{- $href = .RelPermalink -}}{{- else -}}{{- $href = $linkParam -}}{{- end -}}
+      {{- with $.Page.Resources.GetMatch $linkParam -}}
+        {{- $href = .RelPermalink -}}
+      {{- else -}}
+        {{/* Neither an absolute URL nor a matching resource. Warn rather than
+             silently shipping a verbatim relative href, which is trailing-slash
+             sensitive (the very bug #90 targets) and is likely a typo. */}}
+        {{- warnf "figure shortcode on page %q: link=%q matched no image resource and is not an absolute URL; using it verbatim" .Page.Path $linkParam -}}
+        {{- $href = $linkParam -}}
+      {{- end -}}
     {{- end -}}
   {{- else -}}
     {{- $href = $res.RelPermalink -}}


### PR DESCRIPTION
## Summary

Introduces a single, accessible way to place images on the blog, makes every image load regardless of a trailing slash on the post URL, and fills in / cleans up alt text across the site.

Closes #90.

### A reusable image system

- **`figure` shortcode** (`themes/reborn/layouts/shortcodes/figure.html`) — the standard way to place a "presented" image. It:
  - **requires alt text and fails the build** when it is missing, so an image can never ship without a text alternative;
  - resolves the image as a page resource and emits an **absolute URL**, so it loads with or without a trailing slash (issue #90), plus `loading="lazy"` and intrinsic `width`/`height`;
  - corrects for **EXIF orientation** — Hugo's `.Width`/`.Height` ignore the rotation flag that browsers honor, so the emitted dimensions are swapped for rotated images to keep the aspect ratio correct without touching the source file;
  - supports an optional `caption` (rich HTML allowed), `width`, and a flexible `link` (link to the image itself, `false` for none, or an explicit resource/URL — e.g. a thumbnail linking to a full-res image, or an image linking to a source tweet). A build *warning* fires when a caption merely duplicates the alt text.
- **`render-image` hook** (`themes/reborn/layouts/_markup/render-image.html`) — makes plain Markdown `![]()` images trailing-slash-safe with dimensions and lazy loading, no authoring changes needed. It also **emits a build warning when a Markdown image is missing alt text**, so the render hook now backs the same alt-text guarantee as the figure shortcode (the shortcode hard-fails; the hook warns, since it also handles remote/legacy images).

### Alt text

- Filled in alt text for **46 previously empty-alt images** — the baseball Hall of Fame gallery, two journal posts, and the ElixirConf 2018 notes photo gallery (15 photos, surfaced by the new render-hook warning).
- Reviewed and rewrote weak alt text on the older raw-`<img>` posts (vague meme labels rewritten to describe the image; ALL-CAPS transcriptions sentence-cased; presenters named; duplicate alts differentiated).

### Conversions & cleanup

- Converted the hand-written `<img>`/`<figure>` HTML across 20 posts to the shortcode, dropping the inert `data-action="zoom"` (no JS ever backed it) in favor of real click-to-full-size links.
- One intentional exception: the SwiftLint post's **right-floated book cover** stays raw HTML, since a floated inline image isn't what the centered figure shortcode is for.

### Dev tooling

- A **dev-only inline alt-text overlay** (guarded by `hugo.IsServer`, never in production) prints each image's alt text beneath it while browsing locally — handy for exactly this kind of review. It's kept for the foreseeable future as a standing accessibility aid.

## Review locally

Run `hugo server` and open these (the dev overlay shows each image's alt inline):

**New image system in action**
- http://localhost:1313/posts/2026/7/inherited-software-checklist/

**Empty alt text, now filled (galleries)**
- http://localhost:1313/posts/2022/7/baseball-hall-of-fame/ (22 photos, incl. two EXIF-rotated caps)
- http://localhost:1313/posts/2022/8/12-journal/
- http://localhost:1313/posts/2022/12/17-journal/
- http://localhost:1313/posts/2018/9/elixirconf-2018-notes/ (15 conference photos, alt added)

**Raw `<img>` converted + alt text improved**
- http://localhost:1313/posts/2019/1/designing-a-modern-swift-network-stack-video-and-slides/
- http://localhost:1313/posts/2019/1/professional-ios-projects-code-consistency-with-swiftlint/ (floated book cover left raw)
- http://localhost:1313/posts/2019/2/professional-ios-projects-code-documentation/
- http://localhost:1313/posts/2020/6/book-dreaming-in-code/
- http://localhost:1313/posts/2021/3/retro-taxi-project-kickoff/ (thumbnails link to full-res)
- http://localhost:1313/posts/2021/6/programming-terminology/
- http://localhost:1313/posts/2021/9/ecto-schemaless-changesets/
- http://localhost:1313/posts/2021/9/retro-taxi-project-sept-2021-update/
- http://localhost:1313/posts/2021/11/book-thoughts-company-of-one/
- http://localhost:1313/posts/2022/2/moms-passing/
- http://localhost:1313/posts/2022/3/quantum-jira/
- http://localhost:1313/posts/2022/9/26-liveview-native/ (tweet-linked image + memes)
- http://localhost:1313/posts/2022/10/elixir-book-club-testing-book/
- http://localhost:1313/posts/2022/11/4-journal-estimate-wins/
- http://localhost:1313/posts/2022/11/my-standup-format/
- http://localhost:1313/posts/2022/11/thank-you-phillies/
- http://localhost:1313/posts/2023/4/technical-debt/
- http://localhost:1313/posts/2024/12/new-gaming-pc/
- http://localhost:1313/posts/2025/1/a-few-good-memes/
- http://localhost:1313/posts/2025/5/returning-to-self-employment/
