### PR TITLE
Add DuckDuckGo and Google fallback search links (#88)

### DIFF
--- a/themes/reborn/assets/js/search.js
+++ b/themes/reborn/assets/js/search.js
@@ -44,6 +44,7 @@ if (inputBox !== null) {
  */
 function executeSearch(searchQuery) {
     show(document.querySelector('.search-loading'));
+    showExternalSearch(searchQuery);
 
     fetch('/index.json').then(function (response) {
         if (response.status !== 200) {
@@ -64,6 +65,37 @@ function executeSearch(searchQuery) {
         .catch(function (err) {
             console.log('Fetch Error :-S', err);
         });
+    });
+}
+
+/**
+ * Reveals the "search this site elsewhere" links (which appear both above and
+ * below the results), pointing DuckDuckGo and Google at a site-scoped query so
+ * readers can lean on those engines too.
+ * @param {string} searchQuery - The search term to look for
+ */
+function showExternalSearch(searchQuery) {
+    var containers = document.querySelectorAll('.external-search');
+    if (containers.length === 0) {
+        return;
+    }
+
+    var scopedQuery = 'site:mikezornek.com ' + searchQuery;
+    var ddgHref = 'https://duckduckgo.com/?q=' + encodeURIComponent(scopedQuery);
+    var googleHref = 'https://www.google.com/search?q=' + encodeURIComponent(scopedQuery);
+
+    containers.forEach(function (container) {
+        var ddg = container.querySelector('.external-search-ddg');
+        if (ddg !== null) {
+            ddg.href = ddgHref;
+        }
+
+        var google = container.querySelector('.external-search-google');
+        if (google !== null) {
+            google.href = googleHref;
+        }
+
+        container.classList.remove('hidden');
     });
 }
 

--- a/themes/reborn/layouts/_default/search.html
+++ b/themes/reborn/layouts/_default/search.html
@@ -3,6 +3,8 @@
     <div class="mx-auto max-w-screen-md px-4 md:px-0">
       {{ partial "search-form.html" . }}
 
+      {{ partial "search-external.html" (dict "extraClass" "-mt-4 mb-8") }}
+
 
       <div
         class="prose prose-p:leading-[1.5] prose-headings:mb-0 prose-headings:mt-12 prose-p:mt-2 prose-a:text-purple-600 prose-a:visited:text-purple-900 max-w-none"
@@ -14,6 +16,8 @@
           ></div>
           <p class="mt-2 text-gray-600">Searching...</p>
         </div>
+
+        {{ partial "search-external.html" (dict "extraClass" "mt-12 border-t border-gray-200 pt-6") }}
       </div>
 
       <script id="search-result-template" type="text/x-js-template">

--- a/themes/reborn/layouts/partials/search-external.html
+++ b/themes/reborn/layouts/partials/search-external.html
@@ -1,0 +1,21 @@
+<div class="external-search hidden text-sm text-gray-600 {{ .extraClass }}">
+  <p>
+    Search this site with
+    <a
+      class="external-search-ddg text-purple-600 visited:text-purple-900"
+      href="#"
+      rel="noopener"
+    >
+      DuckDuckGo
+    </a>
+    or
+    <a
+      class="external-search-google text-purple-600 visited:text-purple-900"
+      href="#"
+      rel="noopener"
+    >
+      Google
+    </a>
+    for more results.
+  </p>
+</div>

--- a/themes/reborn/layouts/partials/search-external.html
+++ b/themes/reborn/layouts/partials/search-external.html
@@ -1,18 +1,18 @@
-<div class="external-search hidden text-sm text-gray-600 {{ .extraClass }}">
+<div
+  class="external-search hidden text-sm text-gray-600 {{ .extraClass | default "" }}"
+>
   <p>
     Search this site with
     <a
-      class="external-search-ddg text-purple-600 visited:text-purple-900"
+      class="external-search-ddg text-purple-600 visited:text-purple-900 hover:underline"
       href="#"
-      rel="noopener"
     >
       DuckDuckGo
     </a>
     or
     <a
-      class="external-search-google text-purple-600 visited:text-purple-900"
+      class="external-search-google text-purple-600 visited:text-purple-900 hover:underline"
       href="#"
-      rel="noopener"
     >
       Google
     </a>


### PR DESCRIPTION
Resolves #88.

## What

Adds a small "search this site with DuckDuckGo or Google" block to the search page, giving readers a fallback to full-web search engines when the local Fuse.js search comes up short.

- Appears **both above and below** the results, so it's reachable without scrolling.
- Each link runs a **site-scoped** query (`site:mikezornek.com <query>`), URL-encoded, wired up as each search runs.
- Neutral phrasing ("...for more results") rather than "can't find it".

## How

- New partial `themes/reborn/layouts/partials/search-external.html`, included twice with per-placement spacing classes.
- `search.js` reveals both instances and sets their hrefs via class-based selectors (`.external-search`, `.external-search-ddg/-google`).
- Links are color-only (no `underline`) to match the site's prose link style and avoid a Prettier whitespace artifact (`htmlWhitespaceSensitivity: "ignore"` reflows text inside `<a>` tags).

## Testing

- `hugo` builds clean; both instances render and the Tailwind classes (incl. `visited:text-purple-900`, `-mt-4`) are present in the generated CSS.
- Visually confirmed placement top and bottom.