### PR TITLE
Fix heading-level skip on tag and series term pages

### DIFF
--- a/themes/reborn/layouts/_default/taxonomy.html
+++ b/themes/reborn/layouts/_default/taxonomy.html
@@ -39,8 +39,9 @@
 
           {{ with .Content }}{{ . }}{{ end }}
 
+          {{/* Cards sit directly under this page's h1, so their title is an h2. */}}
           {{ range $pages }}
-            {{ partial "post-card.html" (dict "page" . "hideSeries" $isSeries) }}
+            {{ partial "post-card.html" (dict "page" . "hideSeries" $isSeries "headingLevel" "h2") }}
           {{ end }}
         {{ end }}
       </div>

--- a/themes/reborn/layouts/partials/post-card.html
+++ b/themes/reborn/layouts/partials/post-card.html
@@ -2,13 +2,17 @@
   Richer post listing item: title, date, series link, summary, tags.
 
   @context {dict}
-    page       {page}   The post to render. (required)
-    hideSeries {bool}   Omit the series link (e.g. on a series page). (optional)
+    page         {page}   The post to render. (required)
+    hideSeries   {bool}   Omit the series link (e.g. on a series page). (optional)
+    headingLevel {string} Heading tag for the title, e.g. "h2". Default "h3" —
+                          set to match the card's nesting depth on the page so the
+                          heading outline never skips a level. (optional)
 
   @example: {{ partial "post-card.html" (dict "page" .) }}
 */ -}}
 {{- $p := .page }}
 {{- $hideSeries := .hideSeries }}
+{{- $heading := .headingLevel | default "h3" }}
 
 {{- /* Prefer the front-matter description; ignore the placeholder; else auto-summary. */}}
 {{- $summary := $p.Description }}
@@ -18,11 +22,11 @@
 <article
   class="not-prose mb-5 rounded-lg border border-gray-200 border-l-4 border-l-purple-500 bg-white p-5 shadow-xs transition hover:border-purple-300 hover:border-l-purple-600 hover:shadow-md"
 >
-  <h3 class="mt-0 mb-1 text-xl leading-snug font-semibold">
+  {{ printf `<%s class="mt-0 mb-1 text-xl leading-snug font-semibold">` $heading | safeHTML }}
     <a class="text-purple-700 hover:underline" href="{{ $p.RelPermalink }}">
       {{ $p.Title }}
     </a>
-  </h3>
+  {{ printf "</%s>" $heading | safeHTML }}
 
   <p class="mb-1 text-sm text-gray-600">
     <time datetime="{{ $p.Date.Format "2006-01-02" }}">


### PR DESCRIPTION
## What

Term pages (all eight `/tags/*/` pages, plus `/series/*/`) rendered each post card's title as an `h3` directly under the page `h1`, skipping `h2`. Rocket Validator's W3C/axe checkers flagged this as an error on every tag page:

> The heading "h3" (with computed level 3) follows the heading "h1" (with computed level 1), skipping 1 heading level.

## Why it happened

`post-card.html` hardcoded the title as `h3`. That's correct on the home page (h1 → h2 "Recent Blog Posts" → h3 cards) and `/posts/` (under the h2 "Browse by…" sections), but on a term page the card sits directly under the page h1, so h3 is a skip.

## Fix

`post-card.html` now takes an optional `headingLevel` param (default `h3`, so home and `/posts/` are byte-for-byte unchanged). `taxonomy.html` passes `h2` on term pages so the title nests correctly under the page h1.

Resulting outlines:

| Page | Outline |
|---|---|
| Tag/series term pages | h1 → **h2** cards ✅ |
| Home | h1 → h2 → h3 cards (unchanged) |
| `/posts/` | h2 → h3 cards (unchanged) |

Styling is identical — only the tag name varies with nesting depth; the visual classes are untouched.

## Notes

- Heading tags are emitted via `printf … | safeHTML` because Go's `html/template` escapes dynamic tag names. `safeHTML` is safe here since the value is a hardcoded template literal, never user input.
- Verified by rebuilding and inspecting the rendered heading outline on tag, series, home, and `/posts/` pages.