### PR TITLE
Update Now page for July 2026

### DIFF
--- a/content/now.md
+++ b/content/now.md
@@ -30,7 +30,7 @@ I'm also trying to stay connected with old friends, a mix of in-person happy hou
 
 My part-time maintenance contract is now part-part time (about 30 hours a month), so I am pushing to find [more work](https://mikezornek.com/elixir-consulting/). I'm open to part or full time consulting, and even considering full-time job opportunities. Given how tough the market is right now, it's a bit stressful.
 
-My general (and historic) pattern here is to reach out to old peers and publish more. The other half of that is the educational projects and book reading that fuel the writing. 
+My general (and historic) pattern here is to reach out to old peers and publish more. The other half of that is the educational projects and book reading that fuel the writing.
 
 ## Side Projects
 

--- a/content/now.md
+++ b/content/now.md
@@ -5,7 +5,7 @@ layout: onepage
 description: I like to think of a Now page as the things I'd share if you were an old friend and we saw each other and were asking, what's going on? What are you working on? What are you excited about?
 ---
 
-Updated: June 20, 2026
+Updated: July 18, 2026
 
 ## What is a Now page?
 
@@ -13,42 +13,58 @@ I like to think of a Now page as the things I'd share if you were an old friend 
 
 You can find more info here too: <https://nownownow.com/about>
 
+## What I'm Focused On
+
+- Finding consulting work, part or full time, and I'm open to full-time roles too.
+- Publishing more, plus the side project development and reading that feeds it (right now, observability and domain-driven design).
+- Getting the house sorted for some unexpected construction.
+- Moving [LocalCents](https://github.com/zorn/local_cents/) (educational side project) forward.
+
 ## Personal
 
-Doing ok. Just returned from a week down the shore with my sister and a few other family. Getting out of the house and spending time with the family was good for me. It can get isolating living and working from home, and I need to prioritize socializing a bit more than I do by default. 
+The big thing right now is some serious construction I just found out about on Wednesday (7/15). It means emptying the bedroom completely, and possibly opening up the kitchen ceiling. It's really unknown whether I can stay in the house while the work is happening. In the short term, I've been cleaning up, making room in the loft where the bed will probably go, and collapsing some of the other bedroom furniture into my office. It's a bit of a mess. More news will come later.
+
+I'm also trying to stay connected with old friends, a mix of in-person happy hours and virtual coffee chats. Trying to be more intentional about it. I can stay to myself kind of easily.
 
 ## Work
 
-My part-time maintenance contract is now part-part time (about 30 hours a month), so I am pushing efforts to find [more work](https://mikezornek.com/elixir-consulting/). Given how bad the job market is right now, I am a bit stressed out.
+My part-time maintenance contract is now part-part time (about 30 hours a month), so I am pushing to find [more work](https://mikezornek.com/elixir-consulting/). I'm open to part or full time consulting, and even considering full-time job opportunities. Given how tough the market is right now, it's a bit stressful.
 
-While I'll engage the platforms like LinkedIn, my general (and historic) pattern here is to reach out to old peers and just try to publish more. The other half of that effort needs to include some self-improvement / educational tasks (which can, in turn, fuel some publishing).
+My general (and historic) pattern here is to reach out to old peers and publish more. The other half of that is the educational projects and book reading that fuel the writing. 
 
 ## Side Projects
 
-Have been keeping up with some maintenance work for [Flick](https://github.com/zorn/flick/commits/main/). May use that project to test some observability things in the near future but we will see.
+I've been keeping up with maintenance updates for [Flick](https://github.com/zorn/flick/commits/main/), but no real feature work. I do want to study up on observability and use Flick as a test bed for it. So far that has mostly meant reading about it rather than any hands-on movement.
 
-Kicked off my [LocalCents](https://github.com/zorn/local_cents/) project, which is still very early days but currently has some proof of concept things working together (macOS build, Rust-Elixir interop).
+Most of my side project energy over the last six weeks has gone into [LocalCents](https://github.com/zorn/local_cents/), and I'm feeling good about it. I'm just about through the foundational pieces, which means I can soon get into the more interesting [Automerge](https://automerge.org/) conflict logic. I've also started to slowly extract some blog posts from the work along the way.
+
+## Not Doing Right Now
+
+For the next four to eight weeks, I'm intentionally not thinking about any serious commercial product development. I'll keep tinkering on educational and blog-post projects, but the real priority is finding consulting work.
 
 ## Currently Playing
 
-I am currently in the endgame of a Red Dead 2 playthrough (just got John off the farm).
+I finished the Red Dead 2 storyline, epilogue and all. I might chase the remaining achievements, but the last stretch gets monotonous (re-picking every herb in the game, grinding out randomized blackjack hands), so I'm not sure I want to do it all again.
 
-I also have an endgame Stardew Valley farm I jump into on occasion.
+Otherwise I've mostly been playing MLB The Show and a bit of Final Fantasy VII Remake. I also played a session of Civilization VI and might pick that back up. Stardew Valley seems temporarily dropped.
 
 ## Currently Reading
 
-[Learning Domain-Driven Design: Aligning Software Architecture and Business Strategy](https://www.goodreads.com/book/show/57573212-learning-domain-driven-design) -- it is so-so in parts but still working through it.
+Still working through [Art and Fear](https://www.goodreads.com/book/show/187633.Art_and_Fear).
 
-Started the second edition of [Observability Engineering](https://www.oreilly.com/library/view/observability-engineering-2nd/9781098179915/).
+I read the first part of the second edition of [Observability Engineering](https://www.oreilly.com/library/view/observability-engineering-2nd/9781098179915/) and plan to hold off on the rest until I get more hands-on time with observability tools via Flick.
 
-Started [Art and Fear](https://www.goodreads.com/book/show/187633.Art_and_Fear).
+Still making my way through [Learning Domain-Driven Design](https://www.goodreads.com/book/show/57573212-learning-domain-driven-design) little by little.
 
-If you use GoodReads, you can follow me at: <https://www.goodreads.com/zorn711>
+Also started [Show Your Work!](https://www.goodreads.com/book/show/23177969-show-your-work) by Austin Kleon, whose _Keep Going_ I loved.
+
+If you use Goodreads, you can follow me at: <https://www.goodreads.com/zorn711>
 
 ## Currently Watching
 
-Mostly just Phillies baseball and various YouTube things. Will likely grab a Netflix subscription for the All-Star game and so might binge some shows there soon™. 
+Mostly Phillies baseball and various YouTube things. I grabbed a Netflix subscription for the Home Run Derby, so I'm starting to poke around there. I watched an episode of [Derry Girls](https://www.netflix.com/title/80238565) on a recommendation, and I'm considering [Ozark](https://www.netflix.com/title/80117552).
 
 ## Upcoming Events
 
-Nothing on the horizon. I should try to plan some day trips.
+- Family birthday party July 25.
+- Depending on construction, I may try to get away at the shore for a bit and avoid the house noise/dust.


### PR DESCRIPTION
Refreshes the Now page for July 2026.

- Adds a **What I'm Focused On** priority block near the top and a **Not Doing Right Now** section, leaning the page toward direction over status-update details.
- Updates Personal (house construction), Work (still job/consulting hunting), Side Projects (LocalCents progress, Flick maintenance), and the media sections.
- Trims content that would age quickly; links Netflix titles and books.