### PR TITLE
Update Plausible analytics to tagged script snippet

### DIFF
--- a/themes/reborn/layouts/partials/head.html
+++ b/themes/reborn/layouts/partials/head.html
@@ -28,17 +28,23 @@
 {{- end }}
 
 
+<!-- Privacy-friendly analytics by Plausible -->
 <script
-  defer
-  data-domain="mikezornek.com"
-  src="https://plausible.io/js/script.file-downloads.outbound-links.js"
+  async
+  src="https://plausible.io/js/pa-Gwiat_BEp46VFL880jKBR.js"
 ></script>
 <script>
   window.plausible =
     window.plausible ||
     function () {
-      (window.plausible.q = window.plausible.q || []).push(arguments);
+      (plausible.q = plausible.q || []).push(arguments);
     };
+  plausible.init =
+    plausible.init ||
+    function (i) {
+      plausible.o = i || {};
+    };
+  plausible.init();
 </script>
 
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">


### PR DESCRIPTION
Swaps the old Plausible snippet in `themes/reborn/layouts/partials/head.html` for the new tagged script version.

- New loader: `plausible.io/js/pa-Gwiat_BEp46VFL880jKBR.js`
- Adds the `plausible.init()` bootstrap
- The old inline `data-domain` and file-downloads/outbound-links extensions are gone by design; configuration is now managed server-side in the Plausible dashboard.