### PR TITLE
Add Kit newsletter signup form and promotion UTM convention

### DIFF
--- a/playbook/promotion.md
+++ b/playbook/promotion.md
@@ -15,10 +15,64 @@ Some of the places include:
 - Philly Cocoa Slack
 - IndyHall self promotion channel.
 
+## UTM tagging
+
+Tag every shared link with UTM params so Plausible can tell me *which venue*
+produced a signup. Without them, the Campaigns tab is blind and I'm back to
+guessing where to spend promo effort. The workflow: in Plausible, filter by the
+`Newsletter Signup` goal, then read the Campaigns tab to see which source
+converted.
+
+Two params, all lowercase, no spaces:
+
+| Param | Value | What it answers |
+|---|---|---|
+| `utm_source` | the venue (see vocabulary below) | Where do I spend promo effort? |
+| `utm_campaign` | the post slug | Per-post pull (which post the share drove) |
+
+`utm_source` is the load-bearing one: social apps strip the referrer and every
+venue lands on the same post URL, so it's the only way to tell the venues apart.
+`utm_campaign` is partly redundant (the signup event already records which post
+page it fired on) but makes it easy to roll up a post's shares across venues.
+I skip `utm_medium` on purpose: it's just a bucket I can read off the source
+name, so it earns nothing.
+
+Source vocabulary (keep these stable so trends hold across posts):
+
+- `mastodon`, `twitter`
+- `linkedin`, `linkedin-elixir`
+- `reddit`, `elixir-forum`, `elixirstatus`
+- `elixir-slack`, `philly-cocoa`, `indyhall`
+
+A tagged link looks like:
+
+```
+https://mikezornek.com/posts/2026/6/fresh-eyes-on-a-cucumbered-team/?utm_source=mastodon&utm_campaign=cucumbered-team
+```
+
+### On link length in social posts
+
+The tagged URL is long, but it costs almost nothing where it matters:
+
+- **Mastodon and X/Twitter don't count the real length.** Both weigh every link
+  as a flat ~23 characters toward the post limit (X wraps in `t.co`, Mastodon
+  applies a fixed 23-char count regardless of the URL). So UTMs are effectively
+  free against your character budget there. Don't worry about them.
+- **Where the raw URL shows (LinkedIn body, forum posts), it's usually replaced
+  by a link-preview card**, or readers click it regardless of length. Put the
+  URL on its own line at the end so its length doesn't break up the copy.
+- **Avoid third-party link shorteners.** They hide the UTMs, add a redirect hop,
+  and some strip the referrer, which defeats the attribution you tagged for. The
+  long-but-honest URL is the better trade. If you ever must shorten, use one that
+  preserves query params.
+
 ## Share Template
 
 ✏️ New blog: "Fresh Eyes on a Cucumbered Team"
 
 There's a term for what happens when you've been on a team so long you stop noticing its quirks: you've been cucumbered. Here's what fresh eyes can (and can't responsibly) do about it.
 
-https://mikezornek.com/posts/2026/6/fresh-eyes-on-a-cucumbered-team/
+https://mikezornek.com/posts/2026/6/fresh-eyes-on-a-cucumbered-team/?utm_source=mastodon&utm_campaign=cucumbered-team
+
+(Swap `utm_source` per venue; keep `utm_campaign` the same across all shares of
+one post.)

--- a/themes/reborn/assets/js/main.js
+++ b/themes/reborn/assets/js/main.js
@@ -1,1 +1,22 @@
 // Theme specific JS can go here.
+
+// Track newsletter signups as a Plausible custom event.
+//
+// Kit's embedded form renders a <form data-sv-form="..."> element. We listen at
+// the document level (the form is injected asynchronously by Kit's script, and
+// `submit` bubbles) and fire a "Newsletter Signup" goal. Plausible associates
+// the event with the current page, so signups are source-attributed by which
+// post the reader was on. The submit only fires once the browser's built-in
+// email validation passes, so this counts genuine signup attempts.
+document.addEventListener(
+  "submit",
+  function (event) {
+    var form = event.target;
+    if (form && form.getAttribute && form.getAttribute("data-sv-form")) {
+      window.plausible("Newsletter Signup", {
+        props: { path: window.location.pathname },
+      });
+    }
+  },
+  false,
+);

--- a/themes/reborn/assets/js/main.js
+++ b/themes/reborn/assets/js/main.js
@@ -8,15 +8,13 @@
 // the event with the current page, so signups are source-attributed by which
 // post the reader was on. The submit only fires once the browser's built-in
 // email validation passes, so this counts genuine signup attempts.
-document.addEventListener(
-  "submit",
-  function (event) {
-    var form = event.target;
-    if (form && form.getAttribute && form.getAttribute("data-sv-form")) {
-      window.plausible("Newsletter Signup", {
-        props: { path: window.location.pathname },
-      });
-    }
-  },
-  false,
-);
+function trackNewsletterSignup(event) {
+  var form = event.target;
+  if (form && form.getAttribute && form.getAttribute("data-sv-form")) {
+    window.plausible("Newsletter Signup", {
+      props: { path: window.location.pathname },
+    });
+  }
+}
+
+document.addEventListener("submit", trackNewsletterSignup);

--- a/themes/reborn/layouts/_default/single.html
+++ b/themes/reborn/layouts/_default/single.html
@@ -42,6 +42,11 @@
           {{ .Content }}
         </div>
 
+        {{/* Newsletter signup (blog posts only, right after the content) */}}
+        {{ if eq .Section "posts" }}
+          {{ partial "newsletter-signup.html" . }}
+        {{ end }}
+
         {{/* In-series prev/next (reading-order series only) */}}
         {{ partial "series-nav.html" . }}
 

--- a/themes/reborn/layouts/partials/newsletter-signup.html
+++ b/themes/reborn/layouts/partials/newsletter-signup.html
@@ -1,0 +1,15 @@
+{{- /*
+  Kit (formerly ConvertKit) newsletter signup form.
+
+  Rendered at the bottom of blog posts (see single.html), the "25¢ yes" moment
+  right after a reader finishes a post. The Kit script injects the hosted form
+  inline where this <script> tag sits; all copy/styling is managed in the Kit
+  form designer, not here.
+*/ -}}
+<div class="not-prose my-10">
+  <script
+    async
+    data-uid="e6aab68671"
+    src="https://mike-zornek.kit.com/e6aab68671/index.js"
+  ></script>
+</div>


### PR DESCRIPTION
## What

Stands up the blog mailing list capture, per the deliberate plan in the notebook's `Blog Mailing List` and `Goal Tracking & Observability` projects.

### Newsletter form
- New `newsletter-signup` partial embedding the Kit hosted form.
- Rendered at the bottom of every blog post via `single.html`, guarded to the `posts` section so it stays off project and one-off pages (the "25¢ yes" moment, right after the reader is helped).

### Signup tracking
- Document-level `submit` listener in `main.js` fires a Plausible `Newsletter Signup` custom event, keyed on Kit's `data-sv-form` attribute so it catches any Kit form on the page.
- Sends a page-path prop; Plausible ties the event to the post page for free, so signups are source-attributed per post once the `Newsletter Signup` goal is added in the dashboard.

### Promotion UTM convention
- Adds a UTM tagging section to `playbook/promotion.md` so shared links are venue-attributed in Plausible's Campaigns tab.
- Two params: `utm_source` (the venue) and `utm_campaign` (the post slug); `utm_medium` skipped as low value.
- Includes guidance on link length in social posts and why to avoid third-party shorteners.

## Manual steps (done outside this PR)
- `Newsletter Signup` custom-event goal created in Plausible.
- Kit form built and published (`data-uid=e6aab68671`).

## Notes
- Merging to `main` will trigger a Render production deploy (intended).
- The Kit script injects the form client-side, so it won't appear in raw HTML or with JS disabled.