### PR TITLE
Capture signup page as a hidden Kit field for attribution

### DIFF
--- a/themes/reborn/assets/js/main.js
+++ b/themes/reborn/assets/js/main.js
@@ -1,13 +1,47 @@
 // Theme specific JS can go here.
 
-// Track newsletter signups as a Plausible custom event.
+// --- Newsletter signup helpers (Kit forms) ---------------------------------
 //
-// Kit's embedded form renders a <form data-sv-form="..."> element. We listen at
-// the document level (the form is injected asynchronously by Kit's script, and
-// `submit` bubbles) and fire a "Newsletter Signup" goal. Plausible associates
-// the event with the current page, so signups are source-attributed by which
-// post the reader was on. The submit only fires once the browser's built-in
-// email validation passes, so this counts genuine signup attempts.
+// Kit's embedded form renders a <form data-sv-form="..."> element, injected
+// asynchronously by Kit's script.
+
+// 1) Record which page each subscriber signed up from, as a hidden Kit custom
+//    field. This rides the form POST itself, so it is captured even when a
+//    content blocker neutralizes Kit's (and Plausible's) JavaScript. Requires a
+//    "signup_page" custom field to exist in the Kit account, otherwise Kit
+//    silently ignores the value.
+function tagKitFormWithPage(form) {
+  if (form.querySelector('input[name="fields[signup_page]"]')) {
+    return;
+  }
+  var input = document.createElement("input");
+  input.type = "hidden";
+  input.name = "fields[signup_page]";
+  input.value = window.location.pathname;
+  form.appendChild(input);
+}
+
+function tagAllKitForms() {
+  var forms = document.querySelectorAll("form[data-sv-form]");
+  for (var i = 0; i < forms.length; i++) {
+    tagKitFormWithPage(forms[i]);
+  }
+}
+
+// Kit injects its form after load, so tag on DOM ready and again as nodes are
+// added to the page.
+document.addEventListener("DOMContentLoaded", tagAllKitForms);
+if (window.MutationObserver) {
+  new MutationObserver(tagAllKitForms).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+}
+
+// 2) Track submissions as a Plausible custom event. Plausible ties the event to
+//    the current page, giving aggregate per-post attribution for visitors who
+//    aren't blocking it. The submit fires only after the browser's built-in
+//    email validation, so this counts genuine signup attempts.
 function trackNewsletterSignup(event) {
   var form = event.target;
   if (form && form.getAttribute && form.getAttribute("data-sv-form")) {


### PR DESCRIPTION
## What

Records which post each subscriber signed up from, stored per subscriber in Kit.

Injects a hidden `fields[signup_page]` input into Kit's embedded form, populated with the current page path. Because the value rides the form POST itself, it is captured **even when a content blocker neutralizes Kit's and Plausible's JavaScript** — the exact visitors our aggregate/JS tracking misses, and a group this site's technical audience runs at a high rate.

The form is tagged on `DOMContentLoaded` and via a `MutationObserver`, since Kit injects its form asynchronously.

## Why (layers of attribution)

- **Plausible `Newsletter Signup` goal** (already shipped) — aggregate per-page attribution, JS-based, blocker-eroded.
- **Kit native attribution** (zero setup) — referrer + UTM per subscriber; answers "which venue" and pairs with the promotion UTM convention.
- **This change** — the exact on-site post, per subscriber, blocker-proof. Answers "which post."

## Required manual step (blocks correctness, not merge)

Create a **`signup_page` custom field** in the Kit account (Subscribers → Custom Fields). Kit ignores the value if the field key doesn't exist. If Kit assigns a key other than `signup_page`, the input name in `main.js` must be updated to match.

## Verify after deploy

1. Submit a test signup on a live post; confirm the subscriber's `Signup Page` field shows the post path.
2. Repeat **with a content blocker enabled** — the field should still populate (the whole point).

## Not doing

- No `/subscribed` thank-you page — that's branding only, no tracking value. Inline success message stays.