### PR TITLE
Add bob-promise to the new-post archetype [render skip]

### DIFF
--- a/themes/reborn/archetypes/default.md
+++ b/themes/reborn/archetypes/default.md
@@ -7,4 +7,5 @@ images:
 draft: true
 pain: 
 fix: 
+bob-promise: 
 ---


### PR DESCRIPTION
## Summary

Adds a `bob-promise` field to the new-post archetype so it's captured up front on every new post.

It's a planning-only field (not referenced by any theme template, same as `pain`/`fix`), capturing the 30x500 "back-of-book" payoff: *after reading this, you will ___*. I started using it on the *Guarding Against AI Drift* post (#132) and want it available in the template going forward.

No rendered output changes — this only affects the scaffold `hugo new` produces.
