### PR TITLE
Add hashtag conventions to the promotion playbook

### DIFF
--- a/playbook/promotion.md
+++ b/playbook/promotion.md
@@ -16,6 +16,10 @@ Some of the places include:
 - Philly Cocoa Slack
 - IndyHall self promotion channel.
 
+Some venues post as a thread, not just a body: **Elixir Forum**, **Reddit
+r/elixir**, and **ElixirStatus** each need a title. Reuse the blog post's own
+title verbatim rather than inventing a new one.
+
 ## UTM tagging
 
 Tag every shared link with UTM params so Plausible can tell me *which venue*

--- a/playbook/promotion.md
+++ b/playbook/promotion.md
@@ -66,6 +66,50 @@ The tagged URL is long, but it costs almost nothing where it matters:
   long-but-honest URL is the better trade. If you ever must shorten, use one that
   preserves query params.
 
+## Hashtags
+
+Hashtags are the discovery mechanism that carries a post past my own
+followers. They matter most on **Mastodon**, where tags are a primary way
+people find posts (there's no algorithmic feed doing it for them). They help a
+little on **LinkedIn**. Skip them on **Reddit and the forums** — hashtags read
+as spam there; use the venue's own flair/category instead.
+
+The prominent one for anything Elixir-focused:
+
+- **`#elixirlang`** — the load-bearing tag. Use it on every Elixir post. The
+  bare word "elixir" is also potions, cough syrup, and drink brands, so the
+  community disambiguated on `#elixirlang` (mirrors `#golang`, `#swiftlang`).
+  This is the one Elixir folks actually follow.
+
+Add alongside it, when they fit the post:
+
+- **`#myelixirstatus`** — a community convention left over from the Twitter
+  days; posts carrying it get picked up by [elixirstatus.com](https://elixirstatus.com).
+  Worth including on Elixir posts for the extra distribution.
+- **`#elixir`** — plain and high-volume but noisy (catches the non-programming
+  senses). Fine to include as a second Elixir tag; don't rely on it alone.
+- **`#phoenixframework`** — for Phoenix / LiveView-specific posts.
+- **`#erlang`, `#beam`** — for posts that genuinely touch the BEAM or Erlang,
+  not by default.
+
+For the non-Elixir corners of what I write:
+
+- Apple / iOS posts (`ios`, `apple` tags): **`#iOSDev`**, **`#swiftlang`**.
+- Software-craft / practices / AI posts: **`#softwaredevelopment`** or
+  **`#programming`**, plus **`#ai`** / **`#llm`** when AI is the subject (both
+  noisy — one is plenty).
+
+A couple of mechanics:
+
+- **CamelCase multi-word tags** (`#iOSDev`, not `#iosdev`). Mastodon and
+  screen readers split on the capitals, so the tag stays readable.
+- **Two or three tags is the sweet spot.** A wall of hashtags reads as spam and
+  dilutes the ones that matter. Lead with `#elixirlang`.
+- Put tags on their own line at the end of the post, after the link.
+
+So a typical Elixir share carries `#elixirlang #myelixirstatus`, and I reach
+for the others only when the post's subject actually calls for them.
+
 ## Share Template
 
 ✏️ New blog: "Fresh Eyes on a Cucumbered Team"
@@ -74,5 +118,8 @@ There's a term for what happens when you've been on a team so long you stop noti
 
 https://mikezornek.com/posts/2026/6/fresh-eyes-on-a-cucumbered-team/?utm_source=mastodon&utm_campaign=cucumbered-team
 
+#elixirlang #myelixirstatus
+
 (Swap `utm_source` per venue; keep `utm_campaign` the same across all shares of
-one post.)
+one post. Adjust the hashtags to the post's subject — see Hashtags above; drop
+them entirely on Reddit and the forums.)

--- a/playbook/promotion.md
+++ b/playbook/promotion.md
@@ -14,7 +14,7 @@ Some of the places include:
 - https://elixirstatus.com
 - Elixir Forum? https://elixirforum.com/c/learning-resources/blogs-podcasts/60
 - Philly Cocoa Slack
-- IndyHall self promotion channel.
+- 30x500 Slack (share as an ebomb)
 
 Some venues post as a thread, not just a body: **Elixir Forum**, **Reddit
 r/elixir**, and **ElixirStatus** each need a title. Reuse the blog post's own
@@ -47,7 +47,7 @@ Source vocabulary (keep these stable so trends hold across posts):
 - `mastodon`, `twitter`, `bluesky`
 - `linkedin`, `linkedin-elixir`
 - `reddit`, `elixir-forum`, `elixirstatus`
-- `elixir-slack`, `philly-cocoa`, `indyhall`
+- `elixir-slack`, `philly-cocoa`, `30x500`
 
 A tagged link looks like:
 

--- a/playbook/promotion.md
+++ b/playbook/promotion.md
@@ -6,6 +6,7 @@ Some of the places include:
 
 - Personal Mastodon
 - Personal Twitter
+- Personal Bluesky
 - Elixir Slack (#blogs room)
 - LinkedIn
 - LinkedIn Elixir Group
@@ -39,7 +40,7 @@ name, so it earns nothing.
 
 Source vocabulary (keep these stable so trends hold across posts):
 
-- `mastodon`, `twitter`
+- `mastodon`, `twitter`, `bluesky`
 - `linkedin`, `linkedin-elixir`
 - `reddit`, `elixir-forum`, `elixirstatus`
 - `elixir-slack`, `philly-cocoa`, `indyhall`
@@ -58,6 +59,11 @@ The tagged URL is long, but it costs almost nothing where it matters:
   as a flat ~23 characters toward the post limit (X wraps in `t.co`, Mastodon
   applies a fixed 23-char count regardless of the URL). So UTMs are effectively
   free against your character budget there. Don't worry about them.
+- **Bluesky is the exception: inline link text counts against the 300-char
+  limit in full.** A tagged URL can eat a third of the post. So on Bluesky,
+  paste the URL to generate a link card, then delete the raw URL from the text
+  before posting — the card keeps the UTMs and costs zero characters. Only fall
+  back to an inline URL if no card generates, and trim the copy to fit.
 - **Where the raw URL shows (LinkedIn body, forum posts), it's usually replaced
   by a link-preview card**, or readers click it regardless of length. Put the
   URL on its own line at the end so its length doesn't break up the copy.

--- a/playbook/promotion.md
+++ b/playbook/promotion.md
@@ -13,12 +13,15 @@ Some of the places include:
 - Reddit r/elixir
 - https://elixirstatus.com
 - Elixir Forum? https://elixirforum.com/c/learning-resources/blogs-podcasts/60
+- Elixir Discord (#share channel)
 - Philly Cocoa Slack
 - 30x500 Slack (share as an ebomb)
 
 Some venues post as a thread, not just a body: **Elixir Forum**, **Reddit
-r/elixir**, and **ElixirStatus** each need a title. Reuse the blog post's own
-title verbatim rather than inventing a new one.
+r/elixir**, **ElixirStatus**, and the **Elixir Discord #share channel** each
+need a title. Reuse the blog post's own title verbatim rather than inventing a
+new one. The Discord #share channel is a forum channel, so it also takes post
+tags (set `Blog posts` and `Elixir`) in place of hashtags.
 
 ## UTM tagging
 
@@ -46,7 +49,7 @@ Source vocabulary (keep these stable so trends hold across posts):
 
 - `mastodon`, `twitter`, `bluesky`
 - `linkedin`, `linkedin-elixir`
-- `reddit`, `elixir-forum`, `elixirstatus`
+- `reddit`, `elixir-forum`, `elixirstatus`, `elixir-discord`
 - `elixir-slack`, `philly-cocoa`, `30x500`
 
 A tagged link looks like:


### PR DESCRIPTION
## Summary

Adds a **Hashtags** section to `playbook/promotion.md` so post-share hashtags follow a consistent, deliberate convention instead of being improvised each time, and adds **Bluesky** as a promotion venue.

Key decisions recorded:

- **`#elixirlang` is the load-bearing tag** for any Elixir post (disambiguates from the non-programming senses of "elixir"; mirrors `#golang`/`#swiftlang`).
- Secondary Elixir tags: `#myelixirstatus` (feeds elixirstatus.com), `#elixir`, `#phoenixframework`, and `#erlang`/`#beam` when genuinely relevant.
- Non-Elixir corners: `#iOSDev`/`#swiftlang` for Apple posts; `#softwaredevelopment`/`#programming` plus `#ai`/`#llm` for craft/AI posts.
- **Where tags help vs. hurt:** use them on Mastodon, Twitter, and LinkedIn; skip them on Reddit, the forums, Slack, and ElixirStatus, which have their own room/category.
- Mechanics: CamelCase multi-word tags for readability, two or three tags max, tags on their own line after the link.

**Bluesky** additions:

- Added to the venue list and to the `utm_source` vocabulary as `bluesky`.
- Documented the Bluesky-specific gotcha: inline link text counts against the 300-char limit in full, so post via a link card and delete the raw URL rather than pasting it inline.

Also adds a hashtag line (`#elixirlang #myelixirstatus`) to the share template so the convention shows up in the copy-paste example.

## Notes

- Docs-only changes to the playbook; no site content or build impact.
- Both commits carry `[skip render]` so they won't trigger a production deploy.