### PR TITLE
Fix broken Render build: quote front matter value with a colon

### DIFF
--- a/content/posts/2026/7/shim-off-a-dead-elixir-dependency/index.md
+++ b/content/posts/2026/7/shim-off-a-dead-elixir-dependency/index.md
@@ -3,7 +3,7 @@ title: "Shimming Your Way Off a Dead Elixir Dependency"
 date: 2026-07-24T11:46:39-04:00
 description: An abandoned dependency was blocking a major upgrade I needed. Here are the two ways I retire one, and when a shim beats a big-bang rewrite.
 pain: on a long-lived Elixir project, a routine dependency bump stalls because an abandoned library pins an old version of a shared transitive dependency, and ripping it out means editing call sites everywhere in one scary PR
-fix: two ways to retire a stuck dependency: a hard replacement when the footprint is small, or a shim you introduce and prove with comparison tests and then swap in at the call sites as a separate PR
+fix: "two ways to retire a stuck dependency: a hard replacement when the footprint is small, or a shim you introduce and prove with comparison tests and then swap in at the call sites as a separate PR"
 bob-promise: after reading this you'll know how to retire an abandoned Elixir dependency incrementally, without a big-bang PR and without wondering whether you preserved its behavior
 tags:
   - elixir


### PR DESCRIPTION
## Problem

The deploy for #136 failed on Render:

```
ERROR error building site: assemble: failed to create page ... index.md:6:6: mapping value is not allowed in this context
```

The `fix:` front matter value contained an unquoted colon:

```yaml
fix: two ways to retire a stuck dependency: a hard replacement when the footprint is small, ...
```

Hugo's YAML parser reads the second `: ` as a nested mapping and errors out, so the post never deployed and is currently not live.

## Fix

Wrap the `fix:` value in double quotes so the internal colon is treated as literal text. Verified locally: `hugo` now builds clean (exit 0).

## Follow-up

The broader gap (no pre-merge build validation, so Render is the first thing to run `hugo`) is tracked in #137 — a CI build check that would have caught this at PR time.