### PR TITLE
Add a CI Build check to catch Hugo/YAML errors before deploy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,19 @@
+name: Build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+      # Runs the same script Render uses to deploy. Because bin/build.sh sets
+      # `errexit`, any Hugo error (bad YAML front matter, broken ref/relref
+      # links, template errors, missing image resources) becomes a red check
+      # that blocks the PR before merge. If this is green, Render will build.
+      - run: ./bin/build.sh

--- a/themes/reborn/archetypes/default.md
+++ b/themes/reborn/archetypes/default.md
@@ -1,11 +1,11 @@
 ---
 title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}
-description: something tweet like
+description: "something tweet like"
 images:
   - posts/2020/6/book-dreaming-in-code/thumnb.jpeg
 draft: true
-pain: 
-fix: 
-bob-promise: 
+pain: ""
+fix: ""
+bob-promise: ""
 ---


### PR DESCRIPTION
Closes #137.

## Problem

The only CI today is Lighthouse, which runs *after* deploy on `main`. That means Render is the first thing to ever run `hugo`, so a build-breaking change (like the unquoted colon in #136) is not caught until after it merges.

## Change

- **New `Build` workflow** (`.github/workflows/build.yaml`) runs the same `bin/build.sh` Render uses on every pull request and push to `main`. Because `bin/build.sh` sets `errexit`, any Hugo error (bad YAML front matter, broken `ref`/`relref` links, template errors, missing image resources) becomes a red check that blocks the PR before merge. If CI is green, Render will build.
- **Archetype prose fields quoted** (`description`, `pain`, `fix`, `bob-promise`) so new posts start colon-safe by default (the optional belt-and-suspenders from the issue).

## Verification

Tested locally with the same Hugo version CI installs (0.161.1):

- Clean content builds (`hugo` exits 0).
- A front-matter value with an unquoted `: ` fails the build (`hugo` exits 1), reproducing the exact `fix:` line from #136.

## Acceptance

- [x] A build workflow runs `hugo` (via `bin/build.sh`) on PRs and on push to `main`
- [x] A front-matter value containing an unquoted `: ` fails the check
- [x] Archetype prose fields are quoted by default