### PR TITLE
Fix trailing-slash double-counting in Plausible analytics

### DIFF
--- a/themes/reborn/layouts/partials/head.html
+++ b/themes/reborn/layouts/partials/head.html
@@ -17,6 +17,9 @@
   <meta name="fediverse:creator" content="{{ . }}">
 {{ end }}
 
+
+<link rel="canonical" href="{{ .Permalink }}">
+
 {{ template "_internal/twitter_cards.html" . }}
 
 {{ with .Site.Params.author.name }}
@@ -44,7 +47,22 @@
     function (i) {
       plausible.o = i || {};
     };
-  plausible.init();
+  // Report every pageview under the page's Hugo-generated canonical URL so
+  // trailing-slash variants (e.g. /post vs /post/) collapse into one row.
+  // Falls back to the URL as-loaded if no canonical link is present.
+  plausible.init({
+    transformRequest: function (payload) {
+      try {
+        var canonical = document.querySelector('link[rel="canonical"]');
+        if (canonical && canonical.href) {
+          var target = new URL(canonical.href);
+          target.search = new URL(payload.u).search;
+          payload.u = target.toString();
+        }
+      } catch (e) {}
+      return payload;
+    },
+  });
 </script>
 
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">


### PR DESCRIPTION
## Problem

Plausible records `location.pathname` verbatim, so a post hit with and without a trailing slash shows up as two separate rows:

| Page | Visitors |
| --- | --- |
| `/posts/2026/7/guarding-against-ai-drift/` | 47 |
| `/posts/2026/7/guarding-against-ai-drift` | 13 |

Our own templates only ever emit the slashed form (`RelPermalink`), so the no-slash hits are external/hand-typed inbound links, which Render serves a `200` for instead of redirecting — so the script fires there too.

## Fix

Two reinforcing changes in `head.html`:

1. **`rel="canonical"` tag** — declares the slashed URL as authoritative so search engines and inbound links converge on it over time (also plain SEO hygiene; the `<head>` had no canonical before).
2. **Plausible `transformRequest` hook** — reports every pageview under the page's Hugo-generated canonical URL, so trailing-slash variants collapse into one row.

### Why read the canonical instead of string-appending a slash

Reading Hugo's own canonical URL is more bulletproof than munging the path:

- Never mis-guesses slugs that contain a dot (e.g. a hypothetical `phoenix-1.7-notes`).
- Preserves the query string, so UTM attribution is unaffected.
- 404s naturally group under `/404.html` instead of leaking odd paths.
- Falls back to the URL as-loaded if no canonical link exists, so it can never make things worse.

## Notes

- **Historical data isn't merged** — Plausible can't retroactively combine the existing rows; this only affects data going forward.
- No infra/redirect change needed. Verified `hugo` builds clean and the canonical renders with the correct trailing slash.