### PR TITLE
Track site searches and 404s as Plausible custom events

### DIFF
--- a/themes/reborn/assets/js/search.js
+++ b/themes/reborn/assets/js/search.js
@@ -55,6 +55,7 @@ function executeSearch(searchQuery) {
         response.json().then(function (pages) {
             var fuse = new Fuse(pages, fuseOptions);
             var result = fuse.search(searchQuery);
+            trackSearch(searchQuery, result.length);
             if (result.length > 0) {
                 populateResults(result);
             } else {
@@ -65,6 +66,31 @@ function executeSearch(searchQuery) {
         .catch(function (err) {
             console.log('Fetch Error :-S', err);
         });
+    });
+}
+
+/**
+ * Reports a search to Plausible as a custom "Search" event. The `query`
+ * property (lowercased/trimmed so casing variants aggregate) shows what people
+ * look for; `results` captures the hit count so zero-result searches — the
+ * clearest signal of missing content — surface in the dashboard.
+ * @param {string} searchQuery - The term that was searched
+ * @param {number} resultCount - How many matches Fuse.js returned
+ */
+function trackSearch(searchQuery, resultCount) {
+    if (typeof window.plausible !== 'function') {
+        return;
+    }
+    var query = String(searchQuery).toLowerCase().trim();
+    if (!query) {
+        return;
+    }
+    window.plausible('Search', {
+        props: {
+            query: query,
+            results: resultCount,
+            has_results: resultCount > 0
+        }
     });
 }
 

--- a/themes/reborn/layouts/404.html
+++ b/themes/reborn/layouts/404.html
@@ -24,6 +24,14 @@
 
   <script>
     (function () {
+      // Record the missing URL to Plausible as a custom "404" event so broken
+      // links and bad guesses show up in the dashboard, broken down by path.
+      if (typeof window.plausible === 'function') {
+        window.plausible('404', {
+          props: { path: location.pathname },
+        });
+      }
+
       // Guess search terms from the requested path, e.g.
       // /posts/2019/1/code-consistency-with-swiftlint/ -> "code consistency with swiftlint"
       var skip = { posts: 1, tags: 1, series: 1, projects: 1, page: 1, random: 1 };


### PR DESCRIPTION
## What

Adds two Plausible custom events so the weekly report can answer "what are people searching for?" and "what are people hitting 404s on?"

- **`Search`** — fired from `search.js` on every site search, with props:
  - `query` — the term, lowercased/trimmed so casing variants aggregate
  - `results` — number of matches
  - `has_results` — `true`/`false` (the `false` breakdown is a direct content-gap signal)
- **`404`** — fired from `404.html` on load, with a `path` prop (the missing URL). This is Plausible's documented 404-tracking pattern.

Both go through the existing `window.plausible(...)` interface that already powers the Outbound Link / Form Submission / Newsletter Signup goals, so there are no changes to `head.html`.

## Follow-up in the Plausible dashboard (not code)

To make these show up:
1. **Site Settings → Goals**: add custom-event goals named `Search` and `404` (exact casing).
2. **Site Settings → Custom Properties**: add `query`, `results`, `has_results`, and `path` to see the breakdowns.

## Verification

`hugo --gc --minify` builds clean.