### PR TITLE
Point the consulting page's closing give at the guardrails post

### DIFF
--- a/themes/reborn/layouts/shortcodes/consulting-closing-give.html
+++ b/themes/reborn/layouts/shortcodes/consulting-closing-give.html
@@ -1,7 +1,14 @@
 {{/* Closing block for the consulting page. Ends on something the reader can take
-  and use rather than another request: the free first-week checklist. The one
-  contact line is framed as a follow-on to running it, so it reads as a next
-  step instead of a fourth "email me" on the same page.
+  and use rather than another request. The one contact line is framed as a
+  follow-on to using it, so it reads as a next step instead of a fourth
+  "email me" on the same page.
+
+  The give points at the AI-drift guardrails post rather than the first-week
+  inherited-software checklist. That checklist is written from the consultant's
+  side of a handoff (its own opening says so), and the visitor here is not
+  arriving at an unfamiliar codebase, they already own one. The guardrails post
+  is Elixir-specific, is a list of things they can turn on themselves this week,
+  and links every check to its real implementation.
 */}}
 
 {{ $c := partial "consulting-classes.html" . }}
@@ -10,19 +17,18 @@
 <div class="{{ $c.card }} my-12">
   <p class="{{ $c.eyebrow }}">Before you hire anyone</p>
 
-  <h2 class="mt-2 text-3xl font-bold">Run the checklist yourself.</h2>
+  <h2 class="mt-2 text-3xl font-bold">Steal my guardrails.</h2>
 
   <p class="mt-4 max-w-2xl text-lg leading-relaxed">
-    This is the list I work through in week one whenever I take over software I
-    did not write: what to check, what to write down, and what to leave alone
-    until you understand it. Free, and useful whether or not you ever hire me.
+    Every automated check I run on my own Elixir project, written up in one
+    place: compiler flags, Credo, Dialyzer, Sobelow, dependency audits, and the
+    CI wiring behind them. Each one links to how it is set up in a real repo, so
+    you can turn on the ones you are missing without me. Free, and useful
+    whether or not you ever hire me.
   </p>
 
-  <a
-    href="/posts/2026/7/inherited-software-checklist/"
-    class="mt-5 {{ $c.cta }}"
-  >
-    Read the checklist
+  <a href="/posts/2026/7/guarding-against-ai-drift/" class="mt-5 {{ $c.cta }}">
+    Read the writeup
   </a>
 
   <p class="mt-5 text-base">


### PR DESCRIPTION
## Why

The closing block on the Elixir Consulting page offered **Stabilizing Inherited Software: My First-Week Checklist** as its free give, under the headline "Run the checklist yourself."

That post is written from the consultant's side of a handoff. Its opening line is "Not every consulting engagement starts with joining a team that's humming along," and its `pain` front matter reads "for a consultant adopting a new project." It is also stack-agnostic, on a page whose whole pitch is Elixir.

The visitor here is not arriving at an unfamiliar codebase. They already own one, have lived in it for years, and are weighing whether to bring in help. Handing them a first-week onboarding list is a peek at my process, not a tool they can use.

## What changed

Swapped the give to **Guarding Against AI Drift: My Automated Elixir Quality Checks**:

- Elixir-specific, matching the rest of the page
- A concrete list of checks the reader can turn on themselves this week
- Every check links to how it is wired in the LocalCents repo, so it is genuinely liftable

New copy, keeping the "Before you hire anyone" eyebrow and the single contact line:

> **Steal my guardrails.**
>
> Every automated check I run on my own Elixir project, written up in one place: compiler flags, Credo, Dialyzer, Sobelow, dependency audits, and the CI wiring behind them. Each one links to how it is set up in a real repo, so you can turn on the ones you are missing without me. Free, and useful whether or not you ever hire me.
>
> [Read the writeup]
>
> When you want a hand with what it turns up, write me at mike@mikezornek.com

"What it turns up" reads better against this post than the old one. Switching Credo strict and Dialyzer on an aging codebase turns up a pile, and that pile is exactly the sprint.

## Notes

- The checklist post is not orphaned. It still appears in Blog Articles and as the exception-burndown focus link in the sprint offer.
- The guardrails post is now linked three times on the page (CI focus, Blog Articles, closing give). The Blog Articles bullet is the redundant one and could be dropped in a follow-up, left alone here to keep this diff to the one block.
- Runner-up considered: **What Is Good Code?** Fits the "should I let an outsider near my code" reader, but it is a values essay rather than a take-home artifact.

## Verification

`hugo` builds clean; Prettier reports no changes.