### PR TITLE
Fix localhost link on the Elixir Club project page

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -39,5 +39,13 @@ hugo version
 # Return to project directory
 cd "$ORIGINAL_DIR"
 
+# Guard against dev-server URLs shipping to production. A link pasted from
+# `hugo server` is broken for every visitor, so fail the build instead.
+echo "Checking for dev-server URLs..."
+if grep -rn -E 'https?://(localhost|127\.0\.0\.1):1313' content static themes data; then
+  echo "ERROR: found dev-server URL(s) above. Use a root-relative link instead."
+  exit 1
+fi
+
 # Now you can add your Hugo build commands here
 hugo --logLevel info

--- a/content/projects/elixir_club.md
+++ b/content/projects/elixir_club.md
@@ -12,7 +12,7 @@ You can check out this kickoff video for a sense of what I was trying to build.
 
 {{<youtube 6WvHGGqfggM>}}
 
-As I shared in my [shut down announcement blog post](http://localhost:1313/posts/2023/7/shutting-down-elixir-club/):
+As I shared in my [shut down announcement blog post](/posts/2023/7/shutting-down-elixir-club/):
 
 > I ran the site on Circle, hosted some weekly events and async project update threads – but the hard truth is that I was not able to create even the modest-sized community that I was aiming for.
 >


### PR DESCRIPTION
The Elixir Club project page linked to the shut-down announcement post via a `hugo server` URL (`http://localhost:1313/...`), so the link was broken for every visitor on production.

## Changes

- `content/projects/elixir_club.md` — use a root-relative link (`/posts/2023/7/shutting-down-elixir-club/`), matching how the rest of the site links internally. Verified with a local build: the rendered page emits `href="/posts/2023/7/shutting-down-elixir-club/"`.
- `bin/build.sh` — added the build-time check the issue suggested. Before Hugo runs, the script greps `content`, `static`, `themes`, and `data` for `localhost:1313` / `127.0.0.1:1313` and fails the build with the offending lines if any are found. Ran against the current tree: clean.

Closes #146