### PR TITLE
Send per-page descriptions to meta description and add Open Graph tags

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Home
+title: Mike Zornek
 sectionHighlight: Home
 layout: home
 ---

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -5,4 +5,5 @@ don't have to be rediscovered later.
 
 One file per topic. Add a new file when a new kind of decision comes up.
 
+- [page-metadata.md](page-metadata.md) — meta description, Open Graph, and Twitter card tags
 - [word-choice.md](word-choice.md) — preferred spellings and word forms

--- a/decisions/page-metadata.md
+++ b/decisions/page-metadata.md
@@ -19,14 +19,21 @@ snippet for another: search engines discount a weak description and synthesize
 their own either way, so the fallback buys nothing and risks worse.
 
 Pages with no `description` front matter therefore emit the site description,
-exactly as they did before. The fix for those is to write the description, not
-to generate one. See the open issue for authoring the missing ones.
+exactly as they did before — currently **251 of 519 rendered pages**, almost
+all of them the pre-2020 post archive plus every page under
+`content/projects/`. The fix for those is to write the description, not to
+generate one; that backfill is issue #155.
 
 ---
 
 ## `og:description` is allowed to differ from `meta description`
 
-This looks like sloppiness and isn't. `_internal/opengraph.html` and
+**Preferred:** Let the two tags disagree on pages with no authored description.
+
+**Rejected:** Hand-writing the Open Graph and Twitter blocks so a single
+expression feeds all three tags.
+
+**Why:** This looks like sloppiness and isn't. `_internal/opengraph.html` and
 `_internal/twitter_cards.html` both use their own chain:
 
 ```go-html-template
@@ -48,8 +55,13 @@ The two tags have different consumers and different failure modes:
   suburbs of Philadelphia" tells a reader nothing about the link. The page's own
   first two sentences, imperfect as they are, tell them something.
 
-Once every page has an authored `description`, the divergence disappears on its
-own, because both chains start at `.Description`.
+Once every page has an authored `description` (#155), the divergence
+disappears on its own, because both chains start at `.Description`.
+
+The one thing to keep in step is escaping: `head.html` applies
+`plainify | htmlUnescape`, matching the embedded templates. Without the
+`htmlUnescape`, `plainify` returns `template.HTML` and Go stops escaping, so a
+description containing a bare `&` emits it raw.
 
 ---
 
@@ -61,8 +73,8 @@ existing `_internal/twitter_cards.html`.
 **Rejected:** A hand-written partial giving one canonical description
 expression across all three tags.
 
-**Why:** Hand-rolling buys consistency on ~34 pages that are going to get
-authored descriptions anyway, and costs roughly 35 lines we'd own forever —
+**Why:** Hand-rolling buys consistency on the pages that are going to get
+authored descriptions anyway (#155), and costs roughly 35 lines we'd own —
 including `og:site_name`, `og:type`, `article:section`,
 `article:published_time`, `article:modified_time`, and `article:tag`, which the
 embedded template already emits correctly and keeps current across Hugo
@@ -98,11 +110,34 @@ as a text-only card.
 **Rejected:** Falling back to `images/zorn_square.png` via `site.Params.images`.
 
 **Why:** The only social-usable asset on the site is a 480×480 avatar. Setting
-`site.Params.images` would apply it to the 179 posts that carry no image of
-their own — the same picture on most of the blog — and would also flip
+`site.Params.images` would apply it to the **394 of 447 posts** that carry no
+image of their own — the same picture on most of the blog — and would also flip
 `twitter:card` to `summary_large_image` for all of them, claiming a large image
 where there's only a small square. Generating a real per-post image is the
-actual fix and is tracked separately.
+actual fix, tracked in #103.
+
+Worth knowing: a page that _does_ set `images` gets `summary_large_image`
+regardless of the file's dimensions, so pointing `images` at a small square
+produces exactly the mismatch described above. `elixir-consulting.md` and
+`values.md` both point at the 480×480 avatar today.
+
+---
+
+## The home page's title is `Mike Zornek`, not `Home`
+
+**Preferred:** `title: Mike Zornek` in `content/_index.md`.
+
+**Rejected:** Keeping `title: Home` and special-casing `.IsHome` in the
+metadata templates.
+
+**Why:** `og:title` and `twitter:title` both read `.Title`, so the front page
+was going to share as "Home". The embedded templates can't be told otherwise
+without hand-rolling them, but the title itself has no other consumer: the
+`<h1>` in `home.html` is hardcoded ("Who is Mike Zornek?"), the nav highlights
+off `sectionHighlight`, and `index.json` ranges `.Site.RegularPages`, which
+excludes the home page. So renaming it fixes both tags and changes nothing
+visible. The `.IsHome` branch in the `<title>` tag is now redundant, and is
+left alone as harmless.
 
 ---
 

--- a/decisions/page-metadata.md
+++ b/decisions/page-metadata.md
@@ -1,0 +1,115 @@
+# Page Metadata
+
+How the `<head>` builds `meta description`, Open Graph, and Twitter card tags,
+and why the pieces are wired the way they are. Lives in
+`themes/reborn/layouts/partials/head.html`.
+
+---
+
+## The description chain stops before `.Summary`
+
+**Preferred:** `.Description` → `site.Params.description`
+
+**Rejected:** `.Description` → `.Summary` → `site.Params.description`
+
+**Why:** `.Summary` is Hugo's auto-extract of the opening prose. On the project
+pages it repeats the title ("Franklin Franklin was a project written in...")
+and runs past 300 characters. Feeding that to `meta description` trades one bad
+snippet for another: search engines discount a weak description and synthesize
+their own either way, so the fallback buys nothing and risks worse.
+
+Pages with no `description` front matter therefore emit the site description,
+exactly as they did before. The fix for those is to write the description, not
+to generate one. See the open issue for authoring the missing ones.
+
+---
+
+## `og:description` is allowed to differ from `meta description`
+
+This looks like sloppiness and isn't. `_internal/opengraph.html` and
+`_internal/twitter_cards.html` both use their own chain:
+
+```go-html-template
+{{ with or .Description .Summary site.Params.description | plainify | htmlUnescape }}
+```
+
+That includes the `.Summary` step we just rejected above, and we don't control
+it. So on a page with no authored description, `meta description` says
+"Personal website of Mike Zornek..." while `og:description` says whatever the
+page opens with.
+
+The two tags have different consumers and different failure modes:
+
+- **`meta description` feeds search engines**, which treat it as a hint. A weak
+  one gets discarded and replaced with page text. Nothing is lost by falling
+  back to the generic site line.
+- **`og:description` feeds social cards**, which render it verbatim. A card
+  reading "Personal website of Mike Zornek, a developer and teacher from the
+  suburbs of Philadelphia" tells a reader nothing about the link. The page's own
+  first two sentences, imperfect as they are, tell them something.
+
+Once every page has an authored `description`, the divergence disappears on its
+own, because both chains start at `.Description`.
+
+---
+
+## Use Hugo's embedded templates, don't hand-roll the tags
+
+**Preferred:** `{{ template "_internal/opengraph.html" . }}` alongside the
+existing `_internal/twitter_cards.html`.
+
+**Rejected:** A hand-written partial giving one canonical description
+expression across all three tags.
+
+**Why:** Hand-rolling buys consistency on ~34 pages that are going to get
+authored descriptions anyway, and costs roughly 35 lines we'd own forever —
+including `og:site_name`, `og:type`, `article:section`,
+`article:published_time`, `article:modified_time`, and `article:tag`, which the
+embedded template already emits correctly and keeps current across Hugo
+upgrades.
+
+The embedded template also reads `_funcs/get-page-images`, which resolves the
+`images` front matter and auto-detects page resources matching `*feature*`,
+`*cover*`, or `*thumbnail*`. Note the archetype's `thumb.jpeg` convention does
+**not** match `*thumbnail*`.
+
+---
+
+## No truncation in the template
+
+**Preferred:** Emit the description as authored.
+
+**Rejected:** `truncate 160`.
+
+**Why:** Truncation is the consumer's job — Google clips the display around
+155–160 characters but reads the whole string, and social cards clip on their
+own. Doing it in the template hides bad authoring instead of surfacing it, and
+`truncate` cuts wherever it lands rather than where a sentence ends. The
+archetype already asks for "tweet-length"; descriptions that overshoot should
+be rewritten by hand.
+
+---
+
+## No fallback `og:image`
+
+**Preferred:** Posts without `images` front matter emit no `og:image` and share
+as a text-only card.
+
+**Rejected:** Falling back to `images/zorn_square.png` via `site.Params.images`.
+
+**Why:** The only social-usable asset on the site is a 480×480 avatar. Setting
+`site.Params.images` would apply it to the 179 posts that carry no image of
+their own — the same picture on most of the blog — and would also flip
+`twitter:card` to `summary_large_image` for all of them, claiming a large image
+where there's only a small square. Generating a real per-post image is the
+actual fix and is tracked separately.
+
+---
+
+## `locale` is `en-US`, not `en-us`
+
+The embedded Open Graph template derives `og:locale` from
+`site.Language.Locale` by swapping `-` for `_`. Open Graph wants
+`language_TERRITORY` with an uppercase territory, so `hugo.yaml` sets
+`locale: "en-US"` to emit `en_US`. The same value feeds `<html lang>`, where
+both cases are valid BCP 47.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,5 +1,5 @@
 baseURL: "https://mikezornek.com"
-locale: "en-us"
+locale: "en-US"
 title: "Mike Zornek"
 description: Personal website of Mike Zornek, a developer and teacher from the suburbs of Philadelphia.
 theme: "reborn"

--- a/themes/reborn/layouts/partials/head.html
+++ b/themes/reborn/layouts/partials/head.html
@@ -12,7 +12,7 @@
 {{/* Page's own description, falling back to the site's. Deliberately does not
   fall back to `.Summary` — see decisions/page-metadata.md.
 */}}
-{{ with or .Description site.Params.description | plainify }}
+{{ with or .Description site.Params.description | plainify | htmlUnescape }}
   <meta name="description" content="{{ . }}">
 {{ end }}
 

--- a/themes/reborn/layouts/partials/head.html
+++ b/themes/reborn/layouts/partials/head.html
@@ -9,7 +9,10 @@
 
 </title>
 
-{{ with .Site.Params.description }}
+{{/* Page's own description, falling back to the site's. Deliberately does not
+  fall back to `.Summary` — see decisions/page-metadata.md.
+*/}}
+{{ with or .Description site.Params.description | plainify }}
   <meta name="description" content="{{ . }}">
 {{ end }}
 
@@ -20,7 +23,11 @@
 
 <link rel="canonical" href="{{ .Permalink }}">
 
+{{/* Open Graph is what Mastodon, Bluesky, LinkedIn, Slack, and Discord read.
+  Twitter cards stay alongside it for the venues that only speak that.
+*/}}
 {{ template "_internal/twitter_cards.html" . }}
+{{ template "_internal/opengraph.html" . }}
 
 {{ with .Site.Params.author.name }}
   <meta name="author" content="{{ . }}">


### PR DESCRIPTION
Closes #149.

Every page was emitting the site description as its `meta description`, so search engines had one identical snippet for every URL — and the `description` front matter most pages set only ever reached `twitter:description`. There were also no Open Graph tags at all, which is what Mastodon, Bluesky, LinkedIn, Slack, and Discord read when building a link card. Given `playbook/promotion.md` has LinkedIn as the only venue that has produced a signup, and Bluesky link cards as the documented play, the OG half is the one that pays.

## Changes

| File | Change |
|---|---|
| `themes/reborn/layouts/partials/head.html` | description falls back instead of hardcoding; adds `_internal/opengraph.html` |
| `content/_index.md` | `title: Home` → `Mike Zornek` |
| `hugo.yaml` | `locale: "en-us"` → `"en-US"` |
| `decisions/page-metadata.md` | new; + index line in `decisions/README.md` |

## Three decisions that differ from the issue

**1. The description chain skips `.Summary`.** The fix sketched in #149 was `or .Description .Summary site.Params.description`. Tested and rejected: on the project pages `.Summary` repeats the title ("Franklin Franklin was a project written in Elixir, Phoenix, and LiveView...") and runs past 300 characters. Since search engines discard a weak description and synthesize their own anyway, that fallback buys nothing and risks a worse snippet.

**2. `og:description` is allowed to differ from `meta description`.** Hugo's embedded OG template uses its own chain — `.Description → .Summary → site description` — and we don't control it. So on a page with no authored description the two tags now disagree. Deliberate: a search snippet is a hint that gets discounted when weak, but a social card is rendered verbatim, and a project page sharing as "Personal website of Mike Zornek, a developer and teacher..." is strictly worse than its own opening sentences. Different consumers, different right answer. The divergence disappears on its own as descriptions get authored (#155).

**3. No fallback `og:image`.** `images` front matter does feed `og:image` (confirmed), but only 56 of 519 rendered pages carry one. A site-wide fallback would have been one `site.Params.images` line — rejected because the only social-usable asset is a 480×480 avatar, which would put the same picture on most of the blog *and* flip `twitter:card` to `summary_large_image`, claiming a large image where there's only a small square. Generating real per-post images is #103.

Reasoning recorded in `decisions/page-metadata.md` so it doesn't have to be rediscovered.

## Two things found on the way

- The home page would have shared as **"Home"** — its `title` was `Home`, and `og:title`/`twitter:title` both read `.Title`. Nothing else consumes it (the `h1` is hardcoded, the nav uses `sectionHighlight`, `index.json` ranges `RegularPages`), so renaming fixes both tags and changes nothing visible.
- `og:locale` emitted `en_us`; Open Graph wants `language_TERRITORY`, so `locale` is now `en-US` and it emits `en_US`.

## Verified

Built before and after, compared head tags across seven page types. **710 HTML files both builds**, no warnings.

| Page | Before | After |
|---|---|---|
| home | site desc; `twitter:title` **Home** | site desc; title **Mike Zornek**; full OG |
| post w/ image | site desc | own desc; `og:image` absolute |
| post w/o image | site desc | own desc; no `og:image` (expected) |
| project page | site desc | site desc; `og:description` from summary |
| tag term page | site desc | unchanged + OG (deliberate — low-value pages) |
| consulting | site desc | **the sprint offer copy**; full OG + image |
| plain page | site desc | unchanged + OG |

Site-wide: 218 pages emit a unique description (was 0); `og:title`/`og:description`/`og:url` on all 519 real pages; `og:image` on 56.

Code review caught an escaping gap, fixed in the second commit: `plainify` returns `template.HTML`, which stops Go escaping, so a bare `&` was emitted raw while `og:description` escaped it. The chain now matches the embedded templates (`plainify | htmlUnescape`) — confirmed with a throwaway page.

## Not verified

How LinkedIn, Bluesky, and Mastodon actually render these — that needs the live URL. After deploy: the `curl` check from #149, plus a paste into a Bluesky draft and LinkedIn Post Inspector. See also the note on #74, which this may or may not fix.

## One call left to you

`elixir-consulting.md` and `values.md` point `images` at the 480×480 avatar, so Hugo claims `summary_large_image` for a small square — the mismatch this PR argues against elsewhere. Pre-existing, and it's a content call on the most sales-critical page, so it's documented rather than changed.

## Follow-ups

- #155 — backfill the 232 posts with no description (clean cutoff: 2012–2019 all missing, 2022+ complete) and tighten the 42 over 160 chars
- #156 — CI check on page metadata
- #103 — rescoped to generating OG images