### PR TITLE
Give every page its own description

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Mike Zornek
+description: Mike Zornek is a developer and teacher from the suburbs of Philadelphia, writing about Elixir, Phoenix, iOS, and the craft of shipping software.
 sectionHighlight: Home
 layout: home
 ---

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,5 +1,6 @@
 ---
 title: Contact
+description: "Ways to reach me: email, Mastodon, Bluesky, or grab a slot on my calendar for a chat."
 sectionHighlight: Contact
 layout: onepage
 ---

--- a/content/follow.md
+++ b/content/follow.md
@@ -1,5 +1,6 @@
 ---
 title: Follow
+description: RSS feeds and platform accounts where you can follow my writing and videos, including Mastodon, Bluesky, YouTube, and GitHub.
 sectionHighlight: Follow
 layout: onepage
 aliases: /feeds/

--- a/content/now.md
+++ b/content/now.md
@@ -2,7 +2,7 @@
 title: Now
 sectionHighlight: Now
 layout: onepage
-description: I like to think of a Now page as the things I'd share if you were an old friend and we saw each other and were asking, what's going on? What are you working on? What are you excited about?
+description: What I would tell an old friend who asked what is going on. What I am working on, what I am excited about, what has my attention.
 ---
 
 Updated: July 18, 2026

--- a/content/posts/2012/8/a-change-of-scenery.md
+++ b/content/posts/2012/8/a-change-of-scenery.md
@@ -1,6 +1,7 @@
 ---
 title: A Change of Scenery
 date: 2012-08-23T02:43:27+00:00
+description: I packed up my iMac and left the coworking space for a while. Not about IndyHall, about my own trouble balancing time.
 aliases: /2012/08/22/a-change-of-scenery/
 tags:
   - career

--- a/content/posts/2012/8/a-new-beginning.md
+++ b/content/posts/2012/8/a-new-beginning.md
@@ -1,6 +1,7 @@
 ---
 title: A New Beginning
 date: 2012-08-22T02:20:46+00:00
+description: Restarting this blog after folding it into a company site. Why I want one place for all of it again, not just the tech.
 aliases: /2012/08/21/a-new-beginning/
 series:
   - Journals

--- a/content/posts/2012/8/core-intuition.md
+++ b/content/posts/2012/8/core-intuition.md
@@ -1,6 +1,7 @@
 ---
 title: Core Intuition
 date: 2012-08-24T02:48:47+00:00
+description: Core Intuition is a weekly podcast about the indie Mac and iOS software business, hosted by Daniel Jalkut and Manton Reece.
 aliases: /2012/08/23/core-intuition/
 tags:
   - reviews

--- a/content/posts/2012/8/focused-testing-in-xcode.md
+++ b/content/posts/2012/8/focused-testing-in-xcode.md
@@ -1,6 +1,7 @@
 ---
 title: Focused Testing in Xcode
 date: 2012-08-27T03:10:55+00:00
+description: An Xcode tip found while wrestling with RestKit serialization. How to run only the tests you care about right now.
 aliases: /2012/08/26/focused-testing-in-xcode/
 tags:
   - ios

--- a/content/posts/2012/8/researching-new-web-tools.md
+++ b/content/posts/2012/8/researching-new-web-tools.md
@@ -1,6 +1,7 @@
 ---
 title: Researching New Web Tools
 date: 2012-08-31T03:12:52+00:00
+description: Turning a Mac app idea into a dynamic web app, and surveying the frameworks and libraries worth building it on.
 aliases: /2012/08/30/researching-new-web-tools/
 tags:
   - web-development

--- a/content/posts/2012/9/instapaper-gripes.md
+++ b/content/posts/2012/9/instapaper-gripes.md
@@ -1,6 +1,7 @@
 ---
 title: Instapaper Gripes
 date: 2012-09-18T03:17:27+00:00
+description: A list of gripes from a daily Instapaper user who still likes the app. Small annoyances, mostly about how I read.
 aliases: /2012/09/17/instapaper-gripes/
 tags:
   - reviews

--- a/content/posts/2012/9/secondconf-2012-notes.md
+++ b/content/posts/2012/9/secondconf-2012-notes.md
@@ -1,6 +1,7 @@
 ---
 title: SecondConf 2012 Notes
 date: 2012-09-26T03:20:15+00:00
+description: Notes from SecondConf in Chicago, a weekend conference about making great things, with a heavily Apple-flavored crowd.
 aliases: /2012/09/25/secondconf-2012-notes/
 tags:
   - conferences

--- a/content/posts/2013/1/catching-up-how-have-you-been.md
+++ b/content/posts/2013/1/catching-up-how-have-you-been.md
@@ -1,6 +1,7 @@
 ---
 title: "Catching Up: How Have You Been?"
 date: 2013-01-30T03:21:24+00:00
+description: Three months without a post. Catching up on client work, Shindig development, and what has been eating all of my time.
 aliases: /2013/01/29/catching-up-how-have-you-been/
 series:
   - Journals

--- a/content/posts/2013/10/my-new-job-with-dmgctrl.md
+++ b/content/posts/2013/10/my-new-job-with-dmgctrl.md
@@ -1,6 +1,7 @@
 ---
 title: My New Job with DmgCtrl
 date: 2013-10-30T03:00:27+00:00
+description: After almost eight years of self-employment I have taken a job at DmgCtrl in Philadelphia. Why this shop, and why now.
 aliases: /2013/10/29/my-new-job-with-dmgctrl/
 tags:
   - career

--- a/content/posts/2013/11/iboutletcollection.md
+++ b/content/posts/2013/11/iboutletcollection.md
@@ -1,6 +1,7 @@
 ---
 title: IBOutletCollection
 date: 2013-11-28T01:35:39+00:00
+description: A short CocoaHeads show and tell on IBOutletCollection, the outlet type that hands you an array of views instead of one.
 aliases: /2013/11/27/iboutletcollection/
 tags:
   - ios

--- a/content/posts/2013/11/podcast-idea.md
+++ b/content/posts/2013/11/podcast-idea.md
@@ -1,6 +1,7 @@
 ---
 title: Podcast Idea
 date: 2013-11-28T01:54:42+00:00
+description: A podcast I want to exist. Merge Conflicts, where two guests debate Cocoa choices like Core Data versus custom SQL.
 aliases: /2013/11/27/podcast-idea/
 ---
 

--- a/content/posts/2013/11/updating-homebrews-httplistenaddress-default-for-jenkins.md
+++ b/content/posts/2013/11/updating-homebrews-httplistenaddress-default-for-jenkins.md
@@ -1,6 +1,7 @@
 ---
 title: Updating Homebrew’s “httpListenAddress” Default for Jenkins
 date: 2013-11-25T02:49:20+00:00
+description: Homebrew's Jenkins install binds to localhost only. How to change httpListenAddress so you can reach the server from another Mac.
 aliases: /2013/11/24/updating-homebrews-httplistenaddress-default-for-jenkins/
 tags:
   - devops

--- a/content/posts/2013/12/enums-and-switches.md
+++ b/content/posts/2013/12/enums-and-switches.md
@@ -1,6 +1,7 @@
 ---
 title: Enums and Switches
 date: 2013-12-29T17:31:47+00:00
+description: If you branch on an enum, use a switch statement. The compiler will then tell you when you forget to handle a new case.
 aliases: /2013/12/29/enums-and-switches/
 tags:
   - ios

--- a/content/posts/2013/12/setup-bots-status-as-a-screensaver.md
+++ b/content/posts/2013/12/setup-bots-status-as-a-screensaver.md
@@ -1,6 +1,7 @@
 ---
 title: Setup Bots Status as a Screensaver
 date: 2013-12-13T03:55:24+00:00
+description: Retire the family photo screensaver and put your CI status up on the big screen. The screensaver and setup I use.
 aliases: /2013/12/12/setup-bots-status-as-a-screensaver/
 tags:
   - devops

--- a/content/posts/2013/12/xcode-bots-and-branches.md
+++ b/content/posts/2013/12/xcode-bots-and-branches.md
@@ -1,6 +1,7 @@
 ---
 title: Xcode Bots and Branches
 date: 2013-12-13T02:58:05+00:00
+description: A quick tip. Xcode 5 assumes a new Bot runs on your current branch, and you change that from the Bot web interface.
 aliases: /2013/12/12/xcode-bots-and-branches/
 tags:
   - devops

--- a/content/posts/2013/2/aarons-laws-law-and-justice-in-a-digital-age.md
+++ b/content/posts/2013/2/aarons-laws-law-and-justice-in-a-digital-age.md
@@ -1,6 +1,7 @@
 ---
 title: "Aaron’s Laws: Law and Justice in a Digital Age"
 date: 2013-02-23T18:41:30+00:00
+description: A must-watch Lawrence Lessig lecture on the life of Aaron Swartz and the legal battle that led to his death.
 aliases: /2013/02/23/aarons-laws-law-and-justice-in-a-digital-age/
 tags:
   - reviews

--- a/content/posts/2013/2/book-review-the-lean-startup.md
+++ b/content/posts/2013/2/book-review-the-lean-startup.md
@@ -1,6 +1,7 @@
 ---
 title: "Book Review: The Lean Startup"
 date: 2013-02-25T19:16:54+00:00
+description: A review of Eric Ries's The Lean Startup, read while deciding what project to take on after selling ProfitTrain.
 aliases: /2013/02/25/book-review-the-lean-startup/
 tags:
   - books

--- a/content/posts/2013/2/early-ember-js-thoughts.md
+++ b/content/posts/2013/2/early-ember-js-thoughts.md
@@ -1,6 +1,7 @@
 ---
 title: Early Ember.js Thoughts
 date: 2013-02-05T17:03:16+00:00
+description: Three weeks into Ember.js and some early thoughts, starting with the fact that its homepage explains almost nothing.
 aliases: /2013/02/05/early-ember-js-thoughts/
 tags:
   - web-development

--- a/content/posts/2013/2/netflixd-peep-show-and-breaking-bad.md
+++ b/content/posts/2013/2/netflixd-peep-show-and-breaking-bad.md
@@ -1,6 +1,7 @@
 ---
 title: "Netflix’d: Peep Show and Breaking Bad"
 date: 2013-02-07T00:10:36+00:00
+description: I binge shows rather than follow them weekly. What streaming has served up lately, namely Peep Show and Breaking Bad.
 aliases: /2013/02/06/netflixd-peep-show-and-breaking-bad/
 tags:
   - reviews

--- a/content/posts/2013/2/november-12-1955.md
+++ b/content/posts/2013/2/november-12-1955.md
@@ -1,6 +1,7 @@
 ---
 title: November 12, 1955
 date: 2013-02-19T21:31:25+00:00
+description: On the cosmic significance of November 12, 1955, and the Back to the Future quote that has lived in my head ever since.
 aliases: /2013/02/19/november-12-1955/
 series:
   - Journals

--- a/content/posts/2013/2/xcode-documentation-downloads.md
+++ b/content/posts/2013/2/xcode-documentation-downloads.md
@@ -1,6 +1,7 @@
 ---
 title: Xcode Documentation Downloads
 date: 2013-02-20T19:22:19+00:00
+description: Grabbing Xcode as a DMG saves re-downloading from the Mac App Store, but a 1.3 GB docs download still waits at first launch.
 aliases: /2013/02/20/xcode-documentation-downloads/
 tags:
   - ios

--- a/content/posts/2013/3/announcing-a-new-project-cb-reader.md
+++ b/content/posts/2013/3/announcing-a-new-project-cb-reader.md
@@ -1,6 +1,7 @@
 ---
 title: Announcing a New Project, CB Reader
 date: 2013-03-07T20:29:06+00:00
+description: Announcing CB Reader, a project to centralize your incoming articles and organize them by semantic analysis and social signals.
 aliases: /2013/03/07/announcing-a-new-project-cb-reader/
 tags:
   - side-projects

--- a/content/posts/2013/3/cb-reader-intro-video-and-feature-survey.md
+++ b/content/posts/2013/3/cb-reader-intro-video-and-feature-survey.md
@@ -1,6 +1,7 @@
 ---
 title: CB Reader Intro Video and Feature Survey
 date: 2013-03-23T01:16:46+00:00
+description: The CB Reader intro video is up, along with a feature survey to help me work out what has to make the first launch.
 aliases: /2013/03/22/cb-reader-intro-video-and-feature-survey/
 tags:
   - side-projects

--- a/content/posts/2013/3/lessconf-diversity.md
+++ b/content/posts/2013/3/lessconf-diversity.md
@@ -1,6 +1,7 @@
 ---
 title: LessConf Diversity
 date: 2013-03-14T19:51:58+00:00
+description: I called a LessConf diversity post pretentious and was asked to explain myself. This is the line-by-line explanation.
 aliases: /2013/03/14/lessconf-diversity/
 tags:
   - conferences

--- a/content/posts/2013/3/more-google-reader-thoughts.md
+++ b/content/posts/2013/3/more-google-reader-thoughts.md
@@ -1,6 +1,7 @@
 ---
 title: More Google Reader Thoughts
 date: 2013-03-14T03:25:01+00:00
+description: Google Reader was two things, a web app and an unofficial API, and the second one is why its shutdown hurts so much.
 aliases: /2013/03/13/more-google-reader-thoughts/
 tags:
   - side-projects

--- a/content/posts/2013/3/running-lean-building-our-lean-canvas.md
+++ b/content/posts/2013/3/running-lean-building-our-lean-canvas.md
@@ -1,6 +1,7 @@
 ---
 title: "Running Lean: Building Our Lean Canvas"
 date: 2013-03-14T00:44:02+00:00
+description: Building a Lean Canvas for CB Reader, using Ash Maurya's Running Lean to turn vague ideas into testable hypotheses.
 aliases: /2013/03/13/running-lean-building-our-lean-canvas/
 tags:
   - side-projects

--- a/content/posts/2013/3/running-lean-problem-interviews.md
+++ b/content/posts/2013/3/running-lean-problem-interviews.md
@@ -1,6 +1,7 @@
 ---
 title: "Running Lean: Problem Interviews"
 date: 2013-03-23T01:24:24+00:00
+description: The next phase of Running Lean for CB Reader is problem interviews, where you find out whether the problem is even real.
 aliases: /2013/03/22/running-lean-problem-interviews/
 tags:
   - side-projects

--- a/content/posts/2013/3/the-end-of-google-reader.md
+++ b/content/posts/2013/3/the-end-of-google-reader.md
@@ -1,6 +1,7 @@
 ---
 title: The End of Google Reader
 date: 2013-03-14T00:00:00+00:00
+description: Google Reader shuts down July 1st and the apps built on it are in trouble. Part of why I started CB Reader.
 aliases: /2013/03/13/the-end-of-google-reader/
 tags:
   - side-projects

--- a/content/posts/2013/4/a-mac-pro-guy-getting-by-in-an-imac-world-storage.md
+++ b/content/posts/2013/4/a-mac-pro-guy-getting-by-in-an-imac-world-storage.md
@@ -1,6 +1,7 @@
 ---
 title: "A Mac Pro Guy Getting By in an iMac World: Storage"
 date: 2013-04-17T04:39:47+00:00
+description: I retired my Mac Pro for a 27-inch iMac and lost all those drive bays. How I solved storage without them.
 aliases: /2013/04/16/a-mac-pro-guy-getting-by-in-an-imac-world-storage/
 tags:
   - apple

--- a/content/posts/2013/4/checking-in-april-flu-new-desk-taxes.md
+++ b/content/posts/2013/4/checking-in-april-flu-new-desk-taxes.md
@@ -1,6 +1,7 @@
 ---
 title: "Checking In: April Flu, New Desk, Taxes"
 date: 2013-04-10T21:17:48+00:00
+description: A quiet few weeks. A stomach bug, a new desk that tore up the office, tax paperwork, and some Starcraft 2.
 aliases: /2013/04/10/checking-in-april-flu-new-desk-taxes/
 series:
   - Journals

--- a/content/posts/2013/4/panics-status-board-for-ipad.md
+++ b/content/posts/2013/4/panics-status-board-for-ipad.md
@@ -1,6 +1,7 @@
 ---
 title: Panic’s Status Board for iPad
 date: 2013-04-24T20:39:42+00:00
+description: A first look at Panic's Status Board for iPad, and why the free-form widgets are where the real power sits.
 aliases: /2013/04/24/panics-status-board-for-ipad/
 tags:
   - reviews

--- a/content/posts/2013/4/philly-startup-weekend.md
+++ b/content/posts/2013/4/philly-startup-weekend.md
@@ -1,6 +1,7 @@
 ---
 title: Philly Startup Weekend
 date: 2013-04-30T00:50:22+00:00
+description: I finally made it to Philly Startup Weekend, 54 hours to launch a startup from nothing. Notes from the weekend.
 aliases: /2013/04/29/philly-startup-weekend/
 tags:
   - conferences

--- a/content/posts/2013/4/retweet-etiquette.md
+++ b/content/posts/2013/4/retweet-etiquette.md
@@ -1,6 +1,7 @@
 ---
 title: Retweet Etiquette
 date: 2013-04-18T20:12:34+00:00
+description: How much self-promotion is too much after you ship? Some thoughts on retweet etiquette, prompted by Dave Winer.
 aliases: /2013/04/18/retweet-etiquette/
 ---
 

--- a/content/posts/2013/4/wwdc-student-scholarships.md
+++ b/content/posts/2013/4/wwdc-student-scholarships.md
@@ -1,6 +1,7 @@
 ---
 title: WWDC Student Scholarships
 date: 2013-04-29T23:17:59+00:00
+description: WWDC 2013 sold out fast, but students still have Apple's scholarship program. I went on one, so apply by May 2nd.
 aliases: /2013/04/29/wwdc-student-scholarships/
 tags:
   - conferences

--- a/content/posts/2013/5/new-lets-play-section.md
+++ b/content/posts/2013/5/new-lets-play-section.md
@@ -1,6 +1,7 @@
 ---
 title: New Let’s Play Section
 date: 2013-05-06T15:38:17+00:00
+description: I added a Let's Play index to the site. What LPs are, and the channels I keep coming back to.
 aliases: /2013/05/06/new-lets-play-section/
 tags:
   - gaming

--- a/content/posts/2013/5/star-trek-into-darkness-nitpicks-and-plot-holes.md
+++ b/content/posts/2013/5/star-trek-into-darkness-nitpicks-and-plot-holes.md
@@ -1,6 +1,7 @@
 ---
 title: "Star Trek: Into Darkness, Nitpicks and Plot Holes"
 date: 2013-05-27T03:50:06+00:00
+description: Spoiler country. My running list of nitpicks and plot holes in Star Trek Into Darkness, starting with Khan's blood.
 aliases: /2013/05/26/star-trek-into-darkness-nitpicks-and-plot-holes/
 tags:
   - reviews

--- a/content/posts/2013/5/updated-reading-list.md
+++ b/content/posts/2013/5/updated-reading-list.md
@@ -1,6 +1,7 @@
 ---
 title: Updated Reading List
 date: 2013-05-05T20:34:21+00:00
+description: I refreshed my reading list page. Take a look, and send recommendations if you have any.
 aliases: /2013/05/05/updated-reading-list/
 tags:
   - books

--- a/content/posts/2013/5/video-introduction-to-objective-c-categories.md
+++ b/content/posts/2013/5/video-introduction-to-objective-c-categories.md
@@ -1,6 +1,7 @@
 ---
 title: "Video: Introduction to Objective-C Categories"
 date: 2013-05-23T18:01:37+00:00
+description: A practice screencast introducing Objective-C categories, made while I work out how to do educational video well.
 aliases: /2013/05/23/video-introduction-to-objective-c-categories/
 tags:
   - ios

--- a/content/posts/2013/6/week-in-review-wwdc-e3-and-cocoaheads.md
+++ b/content/posts/2013/6/week-in-review-wwdc-e3-and-cocoaheads.md
@@ -1,6 +1,7 @@
 ---
 title: "Week in Review: WWDC, E3 and CocoaHeads"
 date: 2013-06-16T21:02:27+00:00
+description: A week in review covering the WWDC keynote and Mavericks, E3, and the latest Philly CocoaHeads meeting.
 aliases: /2013/06/16/week-in-review-wwdc-e3-and-cocoaheads/
 tags:
   - conferences

--- a/content/posts/2014/1/ios-development-things-to-like-things-to-hate.md
+++ b/content/posts/2014/1/ios-development-things-to-like-things-to-hate.md
@@ -1,6 +1,7 @@
 ---
 title: "iOS Development: Things to Like; Things to Hate"
 date: 2014-01-15T01:54:57+00:00
+description: An honest list of what I love about iOS development and what wears on me, from Objective-C to the App Store.
 aliases: /2014/01/14/ios-development-things-to-like-things-to-hate/
 tags:
   - ios

--- a/content/posts/2014/1/megamaneffect-now-on-github.md
+++ b/content/posts/2014/1/megamaneffect-now-on-github.md
@@ -1,6 +1,7 @@
 ---
 title: MegaManEffect now on GitHub
 date: 2014-01-12T20:25:35+00:00
+description: MegaManEffect, my old Mac app that plays a Mega Man 2 animation on app launch, has moved from GoogleCode to GitHub.
 aliases: /2014/01/12/megamaneffect-now-on-github/
 tags:
   - side-projects

--- a/content/posts/2014/10/phone-names.md
+++ b/content/posts/2014/10/phone-names.md
@@ -1,6 +1,7 @@
 ---
 title: Phone Names
 date: 2014-10-02T00:26:27+00:00
+description: I name my hardware after video game characters. A short history of my phone names, starting with an iPhone 4 called Dex.
 aliases: /2014/10/01/phone-names/
 series:
   - Journals

--- a/content/posts/2014/10/quick-cocoalove-recap.md
+++ b/content/posts/2014/10/quick-cocoalove-recap.md
@@ -1,6 +1,7 @@
 ---
 title: Quick CocoaLove Recap
 date: 2014-11-01T00:35:46+00:00
+description: A quick recap of the first CocoaLove. I counted two open laptops all weekend, which tells you how engaged the room was.
 aliases: /2014/10/31/quick-cocoalove-recap/
 tags:
   - conferences

--- a/content/posts/2014/11/an-app-architecture-kata.md
+++ b/content/posts/2014/11/an-app-architecture-kata.md
@@ -1,6 +1,7 @@
 ---
 title: An “App Architecture” Kata
 date: 2014-11-24T02:00:29+00:00
+description: An architecture kata I ran at a CocoaHeads Side Project Saturday. Pair up, design one app, then compare what everyone built.
 aliases: /2014/11/23/an-app-architecture-kata/
 tags:
   - ios

--- a/content/posts/2014/11/cocoaconf-boston-2014-recap.md
+++ b/content/posts/2014/11/cocoaconf-boston-2014-recap.md
@@ -1,6 +1,7 @@
 ---
 title: CocoaConf Boston 2014 Recap
 date: 2014-11-19T01:21:36+00:00
+description: My first CocoaConf, in Boston. High speaker quality, a good weekend, and the reason I plan to catch a future tour stop.
 aliases: /2014/11/18/cocoaconf-boston-2014-recap/
 tags:
   - conferences

--- a/content/posts/2014/11/designing-planning-your-ios-app-workshop-recap.md
+++ b/content/posts/2014/11/designing-planning-your-ios-app-workshop-recap.md
@@ -1,6 +1,7 @@
 ---
 title: "Designing & Planning Your iOS App Workshop Recap"
 date: 2014-11-11T18:34:29+00:00
+description: A recap of the second Philly CocoaHeads workshop, a full day on designing and planning an iOS app before you build it.
 aliases: /2014/11/11/designing-planning-your-ios-app-workshop-recap/
 tags:
   - ios

--- a/content/posts/2014/12/girl-develop-it-introduction-to-ios-development.md
+++ b/content/posts/2014/12/girl-develop-it-introduction-to-ios-development.md
@@ -1,6 +1,7 @@
 ---
 title: "Girl Develop It: Introduction to iOS Development"
 date: 2014-12-31T18:05:32+00:00
+description: Tickets are open for the two-day Introduction to iOS Development class I am teaching for Girl Develop It in February.
 aliases: /2014/12/31/girl-develop-it-introduction-to-ios-development/
 tags:
   - ios

--- a/content/posts/2014/4/side-projects.md
+++ b/content/posts/2014/4/side-projects.md
@@ -1,6 +1,7 @@
 ---
 title: Side Projects
 date: 2014-04-19T03:08:02+00:00
+description: Back after a hectic stretch at work, with an update on GoldCards, the Hearthstone reference app I started at a CocoaHeads hackday.
 aliases: /2014/04/18/side-projects/
 tags:
   - side-projects

--- a/content/posts/2014/5/goldcards-1-1.md
+++ b/content/posts/2014/5/goldcards-1-1.md
@@ -1,6 +1,7 @@
 ---
 title: GoldCards 1.1
 date: 2014-05-20T13:43:03+00:00
+description: GoldCards 1.1 is on the App Store, mostly a data update for the Unleash the Hounds nerf plus a few bug fixes.
 aliases: /2014/05/20/goldcards-1-1/
 tags:
   - side-projects

--- a/content/posts/2014/5/looking-for-feedback-from-twitter-users.md
+++ b/content/posts/2014/5/looking-for-feedback-from-twitter-users.md
@@ -1,6 +1,7 @@
 ---
 title: Looking for feedback from Twitter users
 date: 2014-05-04T02:39:54+00:00
+description: I am working on an app for Twitter users and want to know if the problem is real. A short survey, if you have a minute.
 aliases: /2014/05/03/looking-for-feedback-from-twitter-users/
 tags:
   - side-projects

--- a/content/posts/2014/5/video-getting-started-with-ios-development.md
+++ b/content/posts/2014/5/video-getting-started-with-ios-development.md
@@ -1,6 +1,7 @@
 ---
 title: "Video: Getting Started with iOS Development"
 date: 2014-05-19T13:28:47+00:00
+description: The talk I give to people who ask how to start writing iOS apps, collecting the resources and recommendations I hand out most.
 aliases: /2014/05/19/video-getting-started-with-ios-development/
 tags:
   - ios

--- a/content/posts/2014/6/7-minute-workout-featured-on-apple-com.md
+++ b/content/posts/2014/6/7-minute-workout-featured-on-apple-com.md
@@ -1,6 +1,7 @@
 ---
 title: 7 Minute Workout Featured on Apple.com
 date: 2014-06-10T19:24:00+00:00
+description: 7 Minute Workout, an app I worked on, turns up in Apple's Strength TV ad. Plus news on the DmgCtrl and Tonic merger.
 aliases: /2014/06/10/7-minute-workout-featured-on-apple-com/
 tags:
   - ios

--- a/content/posts/2014/7/july-recap.md
+++ b/content/posts/2014/7/july-recap.md
@@ -1,6 +1,7 @@
 ---
 title: July Recap
 date: 2014-07-29T03:08:13+00:00
+description: A July catch-all. A packed CocoaHeads WWDC meeting, growing Side Project Saturdays, and what else has been going on.
 aliases: /2014/07/28/july-recap/
 series:
   - Journals

--- a/content/posts/2014/8/a-walled-garden-of-shit.md
+++ b/content/posts/2014/8/a-walled-garden-of-shit.md
@@ -1,6 +1,7 @@
 ---
 title: A Walled Garden of Shit
 date: 2014-08-12T00:55:27+00:00
+description: Apple's review guidelines promise to reject apps that are not useful or entertaining. A look at how well that holds up.
 aliases: /2014/08/11/a-walled-garden-of-shit/
 tags:
   - apple

--- a/content/posts/2014/8/on-disappointment-with-clients-who-are-prioritizing-production-over-quality.md
+++ b/content/posts/2014/8/on-disappointment-with-clients-who-are-prioritizing-production-over-quality.md
@@ -1,6 +1,7 @@
 ---
 title: On disappointment with clients who are prioritizing production over quality
 date: 2014-08-24T02:28:52+00:00
+description: A friend asked how to handle clients who value speed over quality. My reply, which starts by looking inward first.
 aliases: /2014/08/23/on-disappointment-with-clients-who-are-prioritizing-production-over-quality/
 tags:
   - consulting

--- a/content/posts/2014/8/philly-craftsmanship.md
+++ b/content/posts/2014/8/philly-craftsmanship.md
@@ -1,6 +1,7 @@
 ---
 title: Philly Craftsmanship
 date: 2014-08-03T00:52:02+00:00
+description: Notes from the first Software as Craft Philadelphia meeting, a good mix of discussion and hands-on pairing.
 aliases: /2014/08/02/philly-craftsmanship/
 tags:
   - software-craft

--- a/content/posts/2014/9/cocoalove-tickets.md
+++ b/content/posts/2014/9/cocoalove-tickets.md
@@ -1,6 +1,7 @@
 ---
 title: CocoaLove Tickets
 date: 2014-09-04T01:02:47+00:00
+description: CocoaLove is next month and we are on the last marketing push. Grab a ticket, or get in touch about sponsoring.
 aliases: /2014/09/03/cocoalove-tickets/
 tags:
   - conferences

--- a/content/posts/2015/1/my-new-job-with-the-big-nerd-ranch.md
+++ b/content/posts/2015/1/my-new-job-with-the-big-nerd-ranch.md
@@ -1,6 +1,7 @@
 ---
 title: My New Job with the Big Nerd Ranch
 date: 2015-01-19T22:26:40+00:00
+description: I accepted a job with Big Nerd Ranch. What Aaron Hillegass's Cocoa Programming book did for my career, and why this move matters.
 aliases: /2015/01/19/my-new-job-with-the-big-nerd-ranch/
 tags:
   - career

--- a/content/posts/2015/10/cocoalove-2015-notes.md
+++ b/content/posts/2015/10/cocoalove-2015-notes.md
@@ -1,6 +1,7 @@
 ---
 title: CocoaLove 2015 Notes
 date: 2015-10-13T00:58:44+00:00
+description: Notes from the second CocoaLove in Philadelphia, a conference about the people in the iOS and Mac community rather than the tech.
 aliases: /2015/10/12/cocoalove-2015-notes/
 tags:
   - conferences

--- a/content/posts/2015/10/how-to-play-wwdc-sessions-at-2x-speed.md
+++ b/content/posts/2015/10/how-to-play-wwdc-sessions-at-2x-speed.md
@@ -1,6 +1,7 @@
 ---
 title: How To Play WWDC Sessions at 2x Speed
 date: 2015-10-14T23:10:37+00:00
+description: The WWDC video library is enormous. Here is how I get through more of the sessions by playing them back at double speed.
 aliases: /2015/10/14/how-to-play-wwdc-sessions-at-2x-speed/
 tags:
   - ios

--- a/content/posts/2015/10/memorable-songs-from-pivotal-indy-moments-of-your-life.md
+++ b/content/posts/2015/10/memorable-songs-from-pivotal-indy-moments-of-your-life.md
@@ -1,6 +1,7 @@
 ---
 title: Memorable Songs from Pivotal Indy Moments of Your Life
 date: 2015-10-25T20:44:04+00:00
+description: Mike Hurley tied a song to the day he quit his job. Here is mine, from when I left ASMP to go full time on Mac development.
 aliases: /2015/10/25/memorable-songs-from-pivotal-indy-moments-of-your-life/
 series:
   - Journals

--- a/content/posts/2015/10/quick-launching-for-cocoa-unit-tests.md
+++ b/content/posts/2015/10/quick-launching-for-cocoa-unit-tests.md
@@ -1,6 +1,7 @@
 ---
 title: Quick Launching for Cocoa Unit Tests
 date: 2015-10-14T01:22:26+00:00
+description: A small tip that makes Cocoa unit test runs launch faster by bailing out of the app delegate early when tests are the target.
 aliases: /2015/10/13/quick-launching-for-cocoa-unit-tests/
 tags:
   - ios

--- a/content/posts/2015/10/staying-secure-on-os-x-with-a-few-unsigned-apps.md
+++ b/content/posts/2015/10/staying-secure-on-os-x-with-a-few-unsigned-apps.md
@@ -1,6 +1,7 @@
 ---
 title: Staying Secure on OS X with a Few Unsigned Apps
 date: 2015-10-19T22:10:33+00:00
+description: Gatekeeper is a fair compromise, but some good Mac software is unsigned. How I run those few apps without dropping my guard.
 aliases: /2015/10/19/staying-secure-on-os-x-with-a-few-unsigned-apps/
 tags:
   - privacy

--- a/content/posts/2015/10/sweating-the-little-details-of-ui-copy.md
+++ b/content/posts/2015/10/sweating-the-little-details-of-ui-copy.md
@@ -1,6 +1,7 @@
 ---
 title: Sweating the Little Details of UI Copy
 date: 2015-10-15T22:10:43+00:00
+description: Interface design is largely word choice. What Apple's HIG says about alert buttons, and why copy deserves the care code gets.
 aliases: /2015/10/15/sweating-the-little-details-of-ui-copy/
 tags:
   - ios

--- a/content/posts/2015/11/24-hours-with-my-ipad-pro.md
+++ b/content/posts/2015/11/24-hours-with-my-ipad-pro.md
@@ -1,6 +1,7 @@
 ---
 title: 24 Hours with My iPad Pro
 date: 2015-11-15T00:46:33+00:00
+description: First impressions after a day with the iPad Pro, from someone who has owned nearly every iPad since the original.
 aliases: /2015/11/14/24-hours-with-my-ipad-pro/
 tags:
   - apple

--- a/content/posts/2015/11/31-days-31-products-1password-2.md
+++ b/content/posts/2015/11/31-days-31-products-1password-2.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: 1Password"
 date: 2015-11-26T18:25:57+00:00
+description: Day 03 of 31 Days, 31 Products. 1Password, for generating and retrieving a unique password for every site you use.
 aliases: /2015/11/26/31-days-31-products-1password-2/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/11/31-days-31-products-acorn.md
+++ b/content/posts/2015/11/31-days-31-products-acorn.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Acorn"
 date: 2015-11-27T20:54:47+00:00
+description: Day 04 of 31 Days, 31 Products. Acorn, a Mac image editor with a truly native feel and some of the best docs around.
 aliases: /2015/11/27/31-days-31-products-acorn/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/11/31-days-31-products-duet.md
+++ b/content/posts/2015/11/31-days-31-products-duet.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Duet"
 date: 2015-11-29T21:15:42+00:00
+description: Day 06 of 31 Days, 31 Products. Duet, which turns an iPad into a wired second monitor with none of the AirPlay lag.
 aliases: /2015/11/29/31-days-31-products-duet/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/11/31-days-31-products-fin.md
+++ b/content/posts/2015/11/31-days-31-products-fin.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Fin"
 date: 2015-11-25T17:05:38+00:00
+description: Day 02 of 31 Days, 31 Products. Fin, an iOS app that turns your device into a large countdown timer for talks and performances.
 aliases: /2015/11/25/31-days-31-products-fin/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/11/31-days-31-products-launch-post.md
+++ b/content/posts/2015/11/31-days-31-products-launch-post.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Launch Post"
 date: 2015-11-24T22:38:33+00:00
+description: Kicking off 31 Days, 31 Products, a month of short write-ups on software I actually use, inspired by Jaimee Newberry.
 aliases: /2015/11/24/31-days-31-products-launch-post/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/11/31-days-31-products-mindnode.md
+++ b/content/posts/2015/11/31-days-31-products-mindnode.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: MindNode"
 date: 2015-11-24T22:42:19+00:00
+description: Day 01 of 31 Days, 31 Products. MindNode, the mind mapping tool I use to branch out from an idea and see where it goes.
 aliases: /2015/11/24/31-days-31-products-mindnode/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/11/31-days-31-products-screenflow.md
+++ b/content/posts/2015/11/31-days-31-products-screenflow.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: ScreenFlow"
 date: 2015-11-28T22:48:48+00:00
+description: Day 05 of 31 Days, 31 Products. ScreenFlow, my tool of choice for recording and editing screencasts.
 aliases: /2015/11/28/31-days-31-products-screenflow/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/11/31-days-31-products-tweetbot-twitterrific.md
+++ b/content/posts/2015/11/31-days-31-products-tweetbot-twitterrific.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: TweetBot & Twitterrific"
 date: 2015-11-30T15:35:51+00:00
+description: Day 07 of 31 Days, 31 Products. TweetBot and Twitterrific, the two clients that have made Twitter usable for me since 2007.
 aliases: /2015/11/30/31-days-31-products-tweetbot-twitterrific/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/11/ios-mobile-design-with-sketch-at-big-nerd-ranch.md
+++ b/content/posts/2015/11/ios-mobile-design-with-sketch-at-big-nerd-ranch.md
@@ -1,6 +1,7 @@
 ---
 title: iOS Mobile Design with Sketch at Big Nerd Ranch
 date: 2015-11-19T03:01:39+00:00
+description: Big Nerd Ranch revamped its mobile design class to teach Sketch alongside design fundamentals, and I finally get to learn it.
 aliases: /2015/11/18/ios-mobile-design-with-sketch-at-big-nerd-ranch/
 tags:
   - ios

--- a/content/posts/2015/11/my-personal-computer-history-how-i-came-to-work-on-the-mac.md
+++ b/content/posts/2015/11/my-personal-computer-history-how-i-came-to-work-on-the-mac.md
@@ -1,6 +1,7 @@
 ---
 title: My Personal Computer History, How I Came to Work on the Mac
 date: 2015-11-30T16:14:25+00:00
+description: How I got from a high school computer lab to writing Mac software for a living, with a pile of Way Back Machine links.
 aliases: /2015/11/30/my-personal-computer-history-how-i-came-to-work-on-the-mac/
 tags:
   - career

--- a/content/posts/2015/11/pragprog-thanksgiving-sale.md
+++ b/content/posts/2015/11/pragprog-thanksgiving-sale.md
@@ -1,6 +1,7 @@
 ---
 title: PragProg Thanksgiving Sale
 date: 2015-11-23T19:08:58+00:00
+description: The Pragmatic Programmers annual Thanksgiving sale is on. My pick this year is The Nature of Software Development.
 aliases: /2015/11/23/pragprog-thanksgiving-sale/
 tags:
   - books

--- a/content/posts/2015/11/rebooting-my-professional-side-projects.md
+++ b/content/posts/2015/11/rebooting-my-professional-side-projects.md
@@ -1,6 +1,7 @@
 ---
 title: Rebooting My Professional Side Projects
 date: 2015-11-17T04:25:06+00:00
+description: Two years after putting Clickable Bliss on hiatus for a full time job, I am starting my own professional side projects again.
 aliases: /2015/11/16/rebooting-my-professional-side-projects/
 tags:
   - side-projects

--- a/content/posts/2015/11/release-notes-conference-thoughts.md
+++ b/content/posts/2015/11/release-notes-conference-thoughts.md
@@ -1,6 +1,7 @@
 ---
 title: Release Notes Conference Thoughts
 date: 2015-11-02T16:38:42+00:00
+description: Thoughts on the Release Notes Conference, an action-oriented event about the business of apps rather than the code.
 aliases: /2015/11/02/release-notes-conference-thoughts/
 tags:
   - conferences

--- a/content/posts/2015/12/31-days-31-products-bbedit.md
+++ b/content/posts/2015/12/31-days-31-products-bbedit.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: BBEdit"
 date: 2015-12-21T22:15:07+00:00
+description: Day 22 of 31 Days, 31 Products. BBEdit, the editor I reach for on huge files, giant find-and-replaces, and config work.
 aliases: /2015/12/21/31-days-31-products-bbedit/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-byword.md
+++ b/content/posts/2015/12/31-days-31-products-byword.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Byword"
 date: 2015-12-04T01:38:20+00:00
+description: Day 10 of 31 Days, 31 Products. Byword, my Markdown editor of choice, plus a pitch for writing in Markdown at all.
 aliases: /2015/12/03/31-days-31-products-byword/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-charles-proxy.md
+++ b/content/posts/2015/12/31-days-31-products-charles-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Charles Proxy"
 date: 2015-12-09T00:04:11+00:00
+description: Day 15 of 31 Days, 31 Products. Charles Proxy, for watching the HTTP traffic your web or mobile app is actually sending.
 aliases: /2015/12/08/31-days-31-products-charles-proxy/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-dash.md
+++ b/content/posts/2015/12/31-days-31-products-dash.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Dash"
 date: 2015-12-29T18:58:12+00:00
+description: Day 26 of 31 Days, 31 Products. Dash, a clean API documentation browser with 150 docsets and good editor integration.
 aliases: /2015/12/29/31-days-31-products-dash/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-elgato-game-capture-hd.md
+++ b/content/posts/2015/12/31-days-31-products-elgato-game-capture-hd.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Elgato Game Capture HD"
 date: 2015-12-12T02:36:44+00:00
+description: Day 17 of 31 Days, 31 Products. Elgato Game Capture HD, a passthrough box for recording whatever is on your console or screen.
 aliases: /2015/12/11/31-days-31-products-elgato-game-capture-hd/
 tags:
   - gaming

--- a/content/posts/2015/12/31-days-31-products-hearthstone.md
+++ b/content/posts/2015/12/31-days-31-products-hearthstone.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Hearthstone"
 date: 2015-12-10T05:01:10+00:00
+description: Day 16 of 31 Days, 31 Products. Hearthstone, the card game that became my way to destress between long coding sessions.
 aliases: /2015/12/10/31-days-31-products-hearthstone/
 tags:
   - gaming

--- a/content/posts/2015/12/31-days-31-products-instapaper.md
+++ b/content/posts/2015/12/31-days-31-products-instapaper.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Instapaper"
 date: 2015-12-06T03:12:52+00:00
+description: Day 12 of 31 Days, 31 Products. Instapaper, for saving articles to read later in a clean, ad-free view.
 aliases: /2015/12/05/31-days-31-products-instapaper/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-omnifocus.md
+++ b/content/posts/2015/12/31-days-31-products-omnifocus.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: OmniFocus"
 date: 2015-12-07T23:22:05+00:00
+description: Day 14 of 31 Days, 31 Products. OmniFocus, the task manager I keep coming back to for Getting Things Done.
 aliases: /2015/12/07/31-days-31-products-omnifocus/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-omnigraffle.md
+++ b/content/posts/2015/12/31-days-31-products-omnigraffle.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: OmniGraffle"
 date: 2015-12-17T19:28:26+00:00
+description: Day 20 of 31 Days, 31 Products. OmniGraffle, my go-to for flow charts, data models, and website wireframes.
 aliases: /2015/12/17/31-days-31-products-omnigraffle/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-postbox.md
+++ b/content/posts/2015/12/31-days-31-products-postbox.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Postbox"
 date: 2015-12-14T01:50:45+00:00
+description: Day 18 of 31 Days, 31 Products. Postbox, the mail client sitting on top of my heavily filtered Gmail setup.
 aliases: /2015/12/13/31-days-31-products-postbox/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-simpholders.md
+++ b/content/posts/2015/12/31-days-31-products-simpholders.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: SimPholders"
 date: 2015-12-01T19:38:25+00:00
+description: Day 08 of 31 Days, 31 Products. SimPholders, a menu bar app that gets you into recent Xcode simulator builds in a click.
 aliases: /2015/12/01/31-days-31-products-simpholders/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-sketch.md
+++ b/content/posts/2015/12/31-days-31-products-sketch.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Sketch"
 date: 2015-12-27T18:19:08+00:00
+description: Day 25 of 31 Days, 31 Products. Sketch, the Mac vector tool that has become a standard for designing user interfaces.
 aliases: /2015/12/27/31-days-31-products-sketch/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-sourcetree.md
+++ b/content/posts/2015/12/31-days-31-products-sourcetree.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: SourceTree"
 date: 2015-12-06T20:52:01+00:00
+description: Day 13 of 31 Days, 31 Products. SourceTree, a Mac front end for Git that makes history and staging much easier to see.
 aliases: /2015/12/06/31-days-31-products-sourcetree/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-status-board.md
+++ b/content/posts/2015/12/31-days-31-products-status-board.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Status Board"
 date: 2015-12-24T01:38:22+00:00
+description: Day 23 of 31 Days, 31 Products. Status Board, Panic's app for turning an old iPad into a wall of actionable data.
 aliases: /2015/12/23/31-days-31-products-status-board/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-superduper.md
+++ b/content/posts/2015/12/31-days-31-products-superduper.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: SuperDuper!"
 date: 2015-12-26T19:47:44+00:00
+description: Day 24 of 31 Days, 31 Products. SuperDuper, the backup tool that kept me calm when my 2TB media drive would not mount.
 aliases: /2015/12/26/31-days-31-products-superduper/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-textexpander.md
+++ b/content/posts/2015/12/31-days-31-products-textexpander.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: TextExpander"
 date: 2015-12-04T17:14:29+00:00
+description: Day 11 of 31 Days, 31 Products. TextExpander, which turns a few typed characters into whatever boilerplate you type most.
 aliases: /2015/12/04/31-days-31-products-textexpander/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-today.md
+++ b/content/posts/2015/12/31-days-31-products-today.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Today"
 date: 2015-12-02T20:09:06+00:00
+description: Day 09 of 31 Days, 31 Products. Today, my weather app of choice, mostly for its visual seven day highs and lows.
 aliases: /2015/12/02/31-days-31-products-today/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-trello.md
+++ b/content/posts/2015/12/31-days-31-products-trello.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Trello"
 date: 2015-12-16T02:38:44+00:00
+description: Day 19 of 31 Days, 31 Products. Trello, an online Kanban board I have leaned on for years to see the flow of work.
 aliases: /2015/12/15/31-days-31-products-trello/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/31-days-31-products-vimeo.md
+++ b/content/posts/2015/12/31-days-31-products-vimeo.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Vimeo"
 date: 2015-12-18T21:55:26+00:00
+description: Day 21 of 31 Days, 31 Products. Vimeo, where I host video because paying for it buys real control over presentation.
 aliases: /2015/12/18/31-days-31-products-vimeo/
 series:
   - 31 Days 31 Products

--- a/content/posts/2015/12/dropbox-shuts-down-mailbox.md
+++ b/content/posts/2015/12/dropbox-shuts-down-mailbox.md
@@ -1,6 +1,7 @@
 ---
 title: Dropbox Shuts Down Mailbox
 date: 2015-12-07T19:37:06+00:00
+description: Dropbox is shutting down Mailbox in February. What its closing note says about how much an email app can really fix.
 aliases: /2015/12/07/dropbox-shuts-down-mailbox/
 ---
 

--- a/content/posts/2015/2/philly-cocoaheads-website-relaunch-project.md
+++ b/content/posts/2015/2/philly-cocoaheads-website-relaunch-project.md
@@ -1,6 +1,7 @@
 ---
 title: Philly CocoaHeads Website Relaunch Project
 date: 2015-02-22T23:37:27+00:00
+description: Kicking off a new side project, rebuilding the Philly CocoaHeads website that has been running on inherited code since 2010.
 aliases: /2015/02/22/philly-cocoaheads-website-relaunch-project/
 tags:
   - web-development

--- a/content/posts/2015/2/questions-for-your-job-hunt.md
+++ b/content/posts/2015/2/questions-for-your-job-hunt.md
@@ -1,6 +1,7 @@
 ---
 title: Questions for Your Job Hunt
 date: 2015-02-10T03:45:49+00:00
+description: The list of questions I built up while job hunting, on culture, process, and pay, meant to tell me whether a company fits.
 aliases: /2015/02/09/questions-for-your-job-hunt/
 tags:
   - career

--- a/content/posts/2015/3/encouraging-impactful-user-content.md
+++ b/content/posts/2015/3/encouraging-impactful-user-content.md
@@ -1,6 +1,7 @@
 ---
 title: Encouraging Impactful User Content
 date: 2015-03-08T18:17:04+00:00
+description: TripAdvisor keeps emailing me about how many people my one review reached, and it is a smart way to keep contributors writing.
 aliases: /2015/03/08/encouraging-impactful-user-content/
 tags:
   - side-projects

--- a/content/posts/2015/3/mike-monteiro-on-selling-design-getting-paid-and-working-with-clients.md
+++ b/content/posts/2015/3/mike-monteiro-on-selling-design-getting-paid-and-working-with-clients.md
@@ -1,6 +1,7 @@
 ---
 title: Mike Monteiro on Selling Design, Getting Paid and Working with Clients
 date: 2015-03-17T18:51:47+00:00
+description: A must-watch Mike Monteiro keynote on presenting creative work, getting paid, and the delicacies of client relationships.
 aliases: /2015/03/17/mike-monteiro-on-selling-design-getting-paid-and-working-with-clients/
 tags:
   - consulting

--- a/content/posts/2015/3/swift-and-cocoa-the-odd-couple.md
+++ b/content/posts/2015/3/swift-and-cocoa-the-odd-couple.md
@@ -1,6 +1,7 @@
 ---
 title: "Swift and Cocoa: The Odd Couple"
 date: 2015-03-04T16:30:06+00:00
+description: Swift wants everything explicit and Cocoa is happy to sort it out later. Two personalities that fate has made roommates.
 aliases: /2015/03/04/swift-and-cocoa-the-odd-couple/
 tags:
   - ios

--- a/content/posts/2015/4/code-patterns-talk-video-now-available.md
+++ b/content/posts/2015/4/code-patterns-talk-video-now-available.md
@@ -1,6 +1,7 @@
 ---
 title: Code Patterns Talk, Video Now Available
 date: 2015-04-23T17:09:17+00:00
+description: My Philly CocoaHeads talk reviewing a handful of iOS code patterns, and where to find our growing archive of meeting videos.
 aliases: /2015/04/23/code-patterns-talk-video-now-available/
 tags:
   - ios

--- a/content/posts/2015/4/farewell-edge-cases.md
+++ b/content/posts/2015/4/farewell-edge-cases.md
@@ -1,6 +1,7 @@
 ---
 title: Farewell Edge Cases
 date: 2015-04-23T15:43:46+00:00
+description: Edge Cases is ending after 128 episodes. A goodbye to the rare Apple developer podcast that actually talked about code.
 aliases: /2015/04/23/farewell-edge-cases/
 tags:
   - reviews

--- a/content/posts/2015/4/know-your-role-contractor-or-consultant.md
+++ b/content/posts/2015/4/know-your-role-contractor-or-consultant.md
@@ -1,6 +1,7 @@
 ---
 title: "Know Your Role: Contractor or Consultant"
 date: 2015-04-22T14:23:12+00:00
+description: Contractor or consultant? Naming which one you are sets client expectations before the relationship goes sideways.
 aliases: /2015/04/22/know-your-role-contractor-or-consultant/
 tags:
   - consulting

--- a/content/posts/2015/4/think-of-the-smallest-possible-code-change-and-then-make-it-smaller.md
+++ b/content/posts/2015/4/think-of-the-smallest-possible-code-change-and-then-make-it-smaller.md
@@ -1,6 +1,7 @@
 ---
 title: Think of the Smallest Possible Code Change, and Then Make It Smaller
 date: 2015-04-16T03:23:25+00:00
+description: A 1,780-line pull request gets a worse review than a small one. Why I keep working to make my changes smaller than that.
 aliases: /2015/04/15/think-of-the-smallest-possible-code-change-and-then-make-it-smaller/
 tags:
   - software-craft

--- a/content/posts/2015/5/wwdc-2015-wish-list.md
+++ b/content/posts/2015/5/wwdc-2015-wish-list.md
@@ -1,6 +1,7 @@
 ---
 title: WWDC 2015 Wish List
 date: 2015-05-02T23:48:58+00:00
+description: "My WWDC 2015 wish list, mostly Swift tooling: refactoring in Xcode, Instruments support, and something like gofmt."
 aliases: /2015/05/02/wwdc-2015-wish-list/
 tags:
   - apple

--- a/content/posts/2015/6/wwdc-events-and-links.md
+++ b/content/posts/2015/6/wwdc-events-and-links.md
@@ -1,6 +1,7 @@
 ---
 title: WWDC Events and Links
 date: 2015-06-01T19:13:14+00:00
+description: WWDC is around the corner and I will be next door at AltConf. Links to the events, the speaker lineup, and the live stream.
 aliases: /2015/06/01/wwdc-events-and-links/
 tags:
   - conferences

--- a/content/posts/2015/9/summer-hiatus-update.md
+++ b/content/posts/2015/9/summer-hiatus-update.md
@@ -1,6 +1,7 @@
 ---
 title: Summer Hiatus Update
 date: 2015-09-24T20:44:59+00:00
+description: Back after a summer away. WWDC in June, a week down the shore, and my first time writing Swift in production.
 aliases: /2015/09/24/summer-hiatus-update/
 series:
   - Journals

--- a/content/posts/2016/1/31-days-31-products-flixster.md
+++ b/content/posts/2016/1/31-days-31-products-flixster.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Flixster"
 date: 2016-01-04T01:52:03+00:00
+description: Day 27 of 31 Days, 31 Products. Flixster, the app I keep on my phone for movie trailers, showtimes, and the release calendar.
 aliases: /2016/01/03/31-days-31-products-flixster/
 tags:
   - reviews

--- a/content/posts/2016/1/31-days-31-products-ioctocat-github-on-your-iphone-and-ipad.md
+++ b/content/posts/2016/1/31-days-31-products-ioctocat-github-on-your-iphone-and-ipad.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: iOctocat, GitHub on your iPhone and iPad"
 date: 2016-01-05T23:11:29+00:00
+description: Day 29 of 31 Days, 31 Products. iOctocat, the iPhone and iPad app I use to track GitHub pull requests while on the road.
 aliases: /2016/01/05/31-days-31-products-ioctocat-github-on-your-iphone-and-ipad/
 tags:
   - reviews

--- a/content/posts/2016/1/31-days-31-products-omnidisksweeper.md
+++ b/content/posts/2016/1/31-days-31-products-omnidisksweeper.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: OmniDiskSweeper"
 date: 2016-01-12T02:40:39+00:00
+description: Day 30 of 31 Days, 31 Products. OmniDiskSweeper, the free OmniGroup tool for finding what is actually eating your hard drive.
 aliases: /2016/01/11/31-days-31-products-omnidisksweeper/
 tags:
   - reviews

--- a/content/posts/2016/1/31-days-31-products-reeder.md
+++ b/content/posts/2016/1/31-days-31-products-reeder.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Reeder"
 date: 2016-01-05T03:05:02+00:00
+description: Day 28 of 31 Days, 31 Products. Reeder, the RSS app that got out of the way when my reading habit came back with the iPad Pro.
 aliases: /2016/01/04/31-days-31-products-reeder/
 tags:
   - reviews

--- a/content/posts/2016/1/31-days-31-products-skitch.md
+++ b/content/posts/2016/1/31-days-31-products-skitch.md
@@ -1,6 +1,7 @@
 ---
 title: "31 Days, 31 Products: Skitch"
 date: 2016-01-15T21:16:17+00:00
+description: Day 31 of 31 Days, 31 Products. Skitch, the screenshot and annotation tool I lean on when I am running an app audit.
 aliases: /2016/01/15/31-days-31-products-skitch/
 tags:
   - reviews

--- a/content/posts/2016/1/managing-remote-teams.md
+++ b/content/posts/2016/1/managing-remote-teams.md
@@ -1,6 +1,7 @@
 ---
 title: Managing Remote Teams
 date: 2016-01-28T21:25:28+00:00
+description: Notes from a Wildbit meetup on managing remote teams, taken as a remote employee curious how other companies handle it.
 aliases: /2016/01/28/managing-remote-teams/
 tags:
   - practices

--- a/content/posts/2016/1/philly-cocoaheads-history.md
+++ b/content/posts/2016/1/philly-cocoaheads-history.md
@@ -1,6 +1,7 @@
 ---
 title: "Philly CocoaHeads: History"
 date: 2016-01-21T21:53:29+00:00
+description: The history of Philly CocoaHeads, written down after years of comparing notes with organizers from other chapters.
 aliases: /2016/01/21/philly-cocoaheads-history/
 tags:
   - meetups

--- a/content/posts/2016/1/video-consuming-json-in-swift.md
+++ b/content/posts/2016/1/video-consuming-json-in-swift.md
@@ -1,6 +1,7 @@
 ---
 title: "Video: Consuming JSON in Swift"
 date: 2016-01-18T17:04:53+00:00
+description: A Philly CocoaHeads talk on the various ways to consume JSON in Swift, including an early look at Big Nerd Ranch's Freddy.
 aliases: /2016/01/18/video-consuming-json-in-swift/
 tags:
   - ios

--- a/content/posts/2016/1/xcode-shortcut-quick-open-in-assistant.md
+++ b/content/posts/2016/1/xcode-shortcut-quick-open-in-assistant.md
@@ -1,6 +1,7 @@
 ---
 title: "Xcode Shortcut: Quick Open in Assistant"
 date: 2016-01-27T20:57:45+00:00
+description: An Xcode shortcut that caused a stir in the Philly CocoaHeads Slack. How to send a Quick Open result to the assistant editor.
 aliases: /2016/01/27/xcode-shortcut-quick-open-in-assistant/
 tags:
   - ios

--- a/content/posts/2016/10/a-few-dental-stories-amongst-subscribers.md
+++ b/content/posts/2016/10/a-few-dental-stories-amongst-subscribers.md
@@ -1,6 +1,7 @@
 ---
 title: A Few Dental Stories Amongst Subscribers
 date: 2016-10-16T21:39:22+00:00
+description: A YouTuber's story about his teeth pulled out my own. Years without dental care, a cracked molar I ignored, and what it cost.
 aliases: /2016/10/16/a-few-dental-stories-amongst-subscribers/
 series:
   - Journals

--- a/content/posts/2016/10/closing-thoughts-on-big-nerd-ranchs-front-end-web-class.md
+++ b/content/posts/2016/10/closing-thoughts-on-big-nerd-ranchs-front-end-web-class.md
@@ -1,6 +1,7 @@
 ---
 title: Closing Thoughts on Big Nerd Ranch’s Front End Web Class
 date: 2016-10-13T01:48:24+00:00
+description: Final thoughts on Big Nerd Ranch's Front End Web class. Who it is for, and what you should already know before you go.
 aliases: /2016/10/12/closing-thoughts-on-big-nerd-ranchs-front-end-web-class/
 tags:
   - web-development

--- a/content/posts/2016/10/documentation-for-nsviewcontroller-initnibnamebundle-is-incorrect.md
+++ b/content/posts/2016/10/documentation-for-nsviewcontroller-initnibnamebundle-is-incorrect.md
@@ -1,6 +1,7 @@
 ---
 title: Documentation for NSViewController init(nibName:bundle:) is incorrect
 date: 2016-10-17T17:48:45+00:00
+description: A short screencast showing why the docs for NSViewController init(nibName:bundle:) are wrong. Radar 28802828 filed.
 aliases: /2016/10/17/documentation-for-nsviewcontroller-initnibnamebundle-is-incorrect/
 tags:
   - ios

--- a/content/posts/2016/10/dongle-emotions.md
+++ b/content/posts/2016/10/dongle-emotions.md
@@ -1,6 +1,7 @@
 ---
 title: Dongle Emotions
 date: 2016-10-30T22:08:18+00:00
+description: Cleaning up the office, opening a pile of new USB-C dongles, and a funny story from my early self-employed contracting days.
 aliases: /2016/10/30/dongle-emotions/
 series:
   - Journals

--- a/content/posts/2016/10/greetings-from-the-ranch.md
+++ b/content/posts/2016/10/greetings-from-the-ranch.md
@@ -1,6 +1,7 @@
 ---
 title: Greetings, from the Ranch
 date: 2016-10-03T02:08:59+00:00
+description: Taking Big Nerd Ranch's Front End Web class this week, plus the wiki side project I plan to build in the evenings.
 aliases: /2016/10/02/greetings-from-the-ranch/
 tags:
   - web-development

--- a/content/posts/2016/10/mid-week-checkin.md
+++ b/content/posts/2016/10/mid-week-checkin.md
@@ -1,6 +1,7 @@
 ---
 title: Mid-week Checkin
 date: 2016-10-06T01:34:06+00:00
+description: A midweek check-in from the Front End Web class, with the full table of contents we have been working through.
 aliases: /2016/10/05/mid-week-checkin/
 series:
   - Journals

--- a/content/posts/2016/10/pre-hello-again-mac-event-thoughts.md
+++ b/content/posts/2016/10/pre-hello-again-mac-event-thoughts.md
@@ -1,6 +1,7 @@
 ---
 title: Pre-“Hello Again” Mac Event Thoughts
 date: 2016-10-22T22:34:21+00:00
+description: Ahead of Apple's Hello Again event, where my aging 2011 iMac leaves me and what I am hoping Apple finally ships.
 aliases: /2016/10/22/pre-hello-again-mac-event-thoughts/
 tags:
   - apple

--- a/content/posts/2016/10/should-i-sell-my-apple-watch.md
+++ b/content/posts/2016/10/should-i-sell-my-apple-watch.md
@@ -1,6 +1,7 @@
 ---
 title: Should I Sell My Apple Watch?
 date: 2016-10-07T21:55:30+00:00
+description: A month in with an Apple Watch Series 2 and I am not sure it earned its place. Talking myself through whether to sell it.
 aliases: /2016/10/07/should-i-sell-my-apple-watch/
 tags:
   - apple

--- a/content/posts/2016/10/you-dont-end-schindlers-list-with-a-pepsi-ad.md
+++ b/content/posts/2016/10/you-dont-end-schindlers-list-with-a-pepsi-ad.md
@@ -1,6 +1,7 @@
 ---
 title: You Don’t End Schindler’s List with a Pepsi Ad.
 date: 2016-10-21T19:20:01+00:00
+description: A Startup podcast episode cut from an emotional moment straight into an ad read. A note on empathy and where ads do not belong.
 aliases: /2016/10/21/you-dont-end-schindlers-list-with-a-pepsi-ad/
 ---
 

--- a/content/posts/2016/11/accessibility.md
+++ b/content/posts/2016/11/accessibility.md
@@ -1,6 +1,7 @@
 ---
 title: Accessibility
 date: 2016-11-05T19:28:54+00:00
+description: Apple opened its fall event with accessibility. What I have learned building for it on iOS, and seeing Philly CocoaHeads take it up.
 aliases: /2016/11/05/accessibility/
 tags:
   - ios

--- a/content/posts/2016/12/rethinking-my-music-storage.md
+++ b/content/posts/2016/12/rethinking-my-music-storage.md
@@ -1,6 +1,7 @@
 ---
 title: Rethinking My Music Storage
 date: 2016-12-10T02:58:07+00:00
+description: 150 GB of music, a 256 GB SSD, and an iTunes library I have never liked. How I rethought where my collection actually lives.
 aliases: /2016/12/09/rethinking-my-music-storage/
 tags:
   - apple

--- a/content/posts/2016/2/how-we-record-talks-at-philly-cocoaheads.md
+++ b/content/posts/2016/2/how-we-record-talks-at-philly-cocoaheads.md
@@ -1,6 +1,7 @@
 ---
 title: How We Record Talks at Philly CocoaHeads
 date: 2016-02-02T22:44:52+00:00
+description: The gear and process we use to record Philly CocoaHeads talks, and why we only ever record the main presentation.
 aliases: /2016/02/02/how-we-record-talks-at-philly-cocoaheads/
 tags:
   - meetups

--- a/content/posts/2016/3/clash-of-the-coders-day-0.md
+++ b/content/posts/2016/3/clash-of-the-coders-day-0.md
@@ -1,6 +1,7 @@
 ---
 title: "Clash of the Coders: Day 0"
 date: 2016-03-30T15:35:33+00:00
+description: Day zero of Clash of the Coders, the annual competition where Big Nerd Ranch shuts down so everyone can build something wizardly.
 aliases: /2016/03/30/clash-of-the-coders-day-0/
 tags:
   - side-projects

--- a/content/posts/2016/6/my-new-pc-gaming-computer.md
+++ b/content/posts/2016/6/my-new-pc-gaming-computer.md
@@ -1,6 +1,7 @@
 ---
 title: My New PC Gaming Computer
 date: 2016-06-19T22:53:29+00:00
+description: The parts list and the reasoning behind my new gaming PC, built mostly to run World of Warcraft and Final Fantasy 14.
 aliases: /2016/06/19/my-new-pc-gaming-computer/
 tags:
   - gaming

--- a/content/posts/2016/6/the-world-needs-a-better-core-data.md
+++ b/content/posts/2016/6/the-world-needs-a-better-core-data.md
@@ -1,6 +1,7 @@
 ---
 title: The World Needs a Better Core Data
 date: 2016-06-07T19:50:24+00:00
+description: A WWDC dream I have mostly given up on. What a better Core Data would look like, starting with migrations worth the name.
 aliases: /2016/06/07/the-world-needs-a-better-core-data/
 tags:
   - ios

--- a/content/posts/2016/7/join-us-at-cocoaconf-dc-sept-9-10th.md
+++ b/content/posts/2016/7/join-us-at-cocoaconf-dc-sept-9-10th.md
@@ -1,6 +1,7 @@
 ---
 title: Join Us at CocoaConf DC, Sept 9-10th
 date: 2016-07-28T00:40:59+00:00
+description: I am speaking at CocoaConf DC on September 9th and 10th, a conference still small enough to actually meet the speakers.
 aliases: /2016/07/27/join-us-at-cocoaconf-dc-sept-9-10th/
 tags:
   - conferences

--- a/content/posts/2016/7/new-blog-rested-experience.md
+++ b/content/posts/2016/7/new-blog-rested-experience.md
@@ -1,6 +1,7 @@
 ---
 title: "New Blog: Rested Experience"
 date: 2016-07-05T15:29:25+00:00
+description: I started a new blog, Rested Experience, to journal the Mac app I have been building for the past month.
 aliases: /2016/07/05/new-blog-rested-experience/
 tags:
   - side-projects

--- a/content/posts/2016/8/regarding-knight-rider-and-delegation.md
+++ b/content/posts/2016/8/regarding-knight-rider-and-delegation.md
@@ -1,6 +1,7 @@
 ---
 title: Regarding Knight Rider and Delegation
 date: 2016-08-02T22:14:36+00:00
+description: Students no longer get the Knight Rider analogy for delegation, and that is a small tragedy for a Big Nerd Ranch instructor.
 aliases: /2016/08/02/regarding-knight-rider-and-delegation/
 tags:
   - ios

--- a/content/posts/2016/9/cocoaconf-dc-2016-recap.md
+++ b/content/posts/2016/9/cocoaconf-dc-2016-recap.md
@@ -1,6 +1,7 @@
 ---
 title: CocoaConf DC 2016 Recap
 date: 2016-09-11T17:41:00+00:00
+description: A recap of speaking at and attending CocoaConf DC 2016, a conference at the comfortable size of about a hundred developers.
 aliases: /2016/09/11/cocoaconf-dc-2016-recap/
 tags:
   - conferences

--- a/content/posts/2016/9/isolating-mac-application-menu-behaviors.md
+++ b/content/posts/2016/9/isolating-mac-application-menu-behaviors.md
@@ -1,6 +1,7 @@
 ---
 title: Isolating Mac Application Menu Behaviors
 date: 2016-09-12T17:34:58+00:00
+description: Adding a Send Feedback item to a Mac app's Help menu, and where the behavior behind a menu item should actually live.
 aliases: /2016/09/12/isolating-mac-application-menu-behaviors/
 tags:
   - ios

--- a/content/posts/2016/9/my-new-experiment-journaling-all-the-things.md
+++ b/content/posts/2016/9/my-new-experiment-journaling-all-the-things.md
@@ -1,6 +1,7 @@
 ---
 title: "My New Experiment: Journaling All the Things"
 date: 2016-09-13T21:34:36+00:00
+description: After watching Mark Dalrymple rubber duck a bug in a text file, I am trying to journal my own assumptions and questions.
 aliases: /2016/09/13/my-new-experiment-journaling-all-the-things/
 tags:
   - practices

--- a/content/posts/2017/11/follow-me-on-micro-blog.md
+++ b/content/posts/2017/11/follow-me-on-micro-blog.md
@@ -1,6 +1,7 @@
 ---
 title: Follow Me on Micro.Blog
 date: 2017-11-07T18:31:33+00:00
+description: I have been leaning toward Micro.blog over Twitter lately, helped along by the new Mac client. Come find me over there.
 aliases: /2017/11/07/follow-me-on-micro-blog/
 ---
 

--- a/content/posts/2017/11/philly-blockchain-tech-meetup.md
+++ b/content/posts/2017/11/philly-blockchain-tech-meetup.md
@@ -1,6 +1,7 @@
 ---
 title: Philly Blockchain Tech Meetup
 date: 2017-11-01T14:41:47+00:00
+description: Ben DiFrancesco is starting Philly Blockchain Tech, a new local meetup. Details on the first meeting and what it will cover.
 aliases: /2017/11/01/philly-blockchain-tech-meetup/
 tags:
   - meetups

--- a/content/posts/2017/2/fever-dreams.md
+++ b/content/posts/2017/2/fever-dreams.md
@@ -1,6 +1,7 @@
 ---
 title: Fever Dreams
 date: 2017-02-07T02:11:31+00:00
+description: A few days lost to a sinus and chest cold, some strange feverish dreams, and a reminder that your health is worth appreciating.
 aliases: /2017/02/06/fever-dreams/
 series:
   - Journals

--- a/content/posts/2017/2/for-the-times-they-are-a-changing.md
+++ b/content/posts/2017/2/for-the-times-they-are-a-changing.md
@@ -1,6 +1,7 @@
 ---
 title: “For the times they are a-changing”
 date: 2017-02-01T17:33:35+00:00
+description: I am no longer an employee of Big Nerd Ranch. What happened, what comes next, and the neck surgery I have scheduled for February.
 aliases: /2017/02/01/for-the-times-they-are-a-changing/
 tags:
   - career

--- a/content/posts/2017/2/neck-surgery-recovery-update.md
+++ b/content/posts/2017/2/neck-surgery-recovery-update.md
@@ -1,6 +1,7 @@
 ---
 title: Neck Surgery Recovery Update
 date: 2017-02-13T19:53:35+00:00
+description: My neck surgery ran longer than planned but was a success. An update on the cyst, the stitches, and the recovery ahead.
 aliases: /2017/02/13/neck-surgery-recovery-update/
 series:
   - Journals

--- a/content/posts/2017/3/introducing-zorn-labs-llc.md
+++ b/content/posts/2017/3/introducing-zorn-labs-llc.md
@@ -1,6 +1,7 @@
 ---
 title: Introducing Zorn Labs LLC
 date: 2017-03-28T17:44:06+00:00
+description: Introducing Zorn Labs LLC, the new home for my consulting and product work, and the kind of iOS work I am looking for.
 aliases: /2017/03/28/introducing-zorn-labs-llc/
 tags:
   - career

--- a/content/posts/2017/5/meet-owldeck-a-new-mac-presentation-app-for-programmers-and-markdown-geeks.md
+++ b/content/posts/2017/5/meet-owldeck-a-new-mac-presentation-app-for-programmers-and-markdown-geeks.md
@@ -1,6 +1,7 @@
 ---
 title: Meet OwlDeck, a New Mac Presentation App for Programmers and Markdown Geeks.
 date: 2017-05-04T02:44:09+00:00
+description: The teaser site for OwlDeck is live, a macOS presentation app for programmers who need to show code and would rather write Markdown.
 aliases: /2017/05/03/meet-owldeck-a-new-mac-presentation-app-for-programmers-and-markdown-geeks/
 tags:
   - side-projects

--- a/content/posts/2017/5/speaking-at-360idev-come-join-us.md
+++ b/content/posts/2017/5/speaking-at-360idev-come-join-us.md
@@ -1,6 +1,7 @@
 ---
 title: Speaking at 360iDev, Come Join Us.
 date: 2017-05-22T16:17:25+00:00
+description: Two of my talk proposals were accepted for 360iDev this August in Denver, including one on the stress around code review.
 aliases: /2017/05/22/speaking-at-360idev-come-join-us/
 tags:
   - conferences

--- a/content/posts/2017/5/video-uikit-is-dead-long-live-uikit.md
+++ b/content/posts/2017/5/video-uikit-is-dead-long-live-uikit.md
@@ -1,6 +1,7 @@
 ---
 title: "Video: UIKit is Dead, Long Live UIKit!"
 date: 2017-05-08T17:52:22+00:00
+description: A lightning talk video on how UIKit's MVC heritage became a bottleneck for new ideas, and what might replace it in the years ahead.
 aliases: /2017/05/08/video-uikit-is-dead-long-live-uikit/
 tags:
   - ios

--- a/content/posts/2017/6/im-teaching-a-half-day-ios-refactoring-workshop-in-july.md
+++ b/content/posts/2017/6/im-teaching-a-half-day-ios-refactoring-workshop-in-july.md
@@ -1,6 +1,7 @@
 ---
 title: I'm Teaching a Half Day iOS Refactoring Workshop in July
 date: 2017-06-12T15:38:30+00:00
+description: I am running my half-day iOS Refactoring workshop publicly in July, on mastering small improvements instead of risky rewrites.
 aliases: /2017/06/12/im-teaching-a-half-day-ios-refactoring-workshop-in-july/
 tags:
   - ios

--- a/content/posts/2017/8/360idev-2017-takeaways.md
+++ b/content/posts/2017/8/360idev-2017-takeaways.md
@@ -1,6 +1,7 @@
 ---
 title: 360iDev 2017 Takeaways
 date: 2017-08-18T01:48:40+00:00
+description: Notes from my first 360iDev in Denver, including where the workshop day worked and where I think the pacing went wrong.
 aliases: /2017/08/17/360idev-2017-takeaways/
 tags:
   - conferences

--- a/content/posts/2018/1/2017-retrospective.md
+++ b/content/posts/2018/1/2017-retrospective.md
@@ -1,6 +1,7 @@
 ---
 title: 2017 Retrospective
 date: 2018-01-04T04:22:45+00:00
+description: 2017 handed me a job loss and a neck surgery. How I rebooted self-employment under a new LLC and got things stable again.
 aliases: /2018/01/03/2017-retrospective/
 tags:
   - career

--- a/content/posts/2018/10/apples-use-of-donations-as-marketing.md
+++ b/content/posts/2018/10/apples-use-of-donations-as-marketing.md
@@ -1,6 +1,7 @@
 ---
 title: Apple’s Use of Donations as Marketing
 date: 2018-10-04T16:07:40+00:00
+description: Apple donated $1 million after the Sulawesi earthquake. Scaled against its profits, that is about $1.86 from someone earning $100,000.
 aliases: /2018/10/04/apples-use-of-donations-as-marketing/
 tags:
   - apple

--- a/content/posts/2018/10/hello-firefox-goodbye-chrome.md
+++ b/content/posts/2018/10/hello-firefox-goodbye-chrome.md
@@ -1,6 +1,7 @@
 ---
 title: Hello Firefox, Goodbye Chrome
 date: 2018-10-08T01:46:34+00:00
+description: Why I dropped Chrome for Firefox, starting with AMP and the years of Google decisions that have been hostile to the open web.
 aliases: /2018/10/08/hello-firefox-goodbye-chrome/
 tags:
   - privacy

--- a/content/posts/2018/10/swift-style-dequeuing-and-populating-cells-from-uitableview.md
+++ b/content/posts/2018/10/swift-style-dequeuing-and-populating-cells-from-uitableview.md
@@ -1,6 +1,7 @@
 ---
 title: "Swift Style: Dequeuing and Populating Cells From UITableView"
 date: 2018-10-15T23:03:40+00:00
+description: UITableView still ships two dequeue methods and only one of them is any good. My style for dequeuing and populating cells in Swift.
 aliases: /2018/10/15/swift-style-dequeuing-and-populating-cells-from-uitableview/
 tags:
   - ios

--- a/content/posts/2018/11/ugly-swift-syntax-for-checking-errors.md
+++ b/content/posts/2018/11/ugly-swift-syntax-for-checking-errors.md
@@ -1,6 +1,7 @@
 ---
 title: Ugly Swift Syntax for Checking Errors
 date: 2018-11-14T19:19:08+00:00
+description: The `if let error = error` pattern is everywhere in iOS callback code. Why I reach for a guard statement instead.
 aliases: /2018/11/14/ugly-swift-syntax-for-checking-errors/
 tags:
   - ios

--- a/content/posts/2018/12/meetup-survey-link-scam.md
+++ b/content/posts/2018/12/meetup-survey-link-scam.md
@@ -1,6 +1,7 @@
 ---
 title: Meetup.com Survey Links
 date: 2018-12-06T17:06:54+00:00
+description: Meetup.com was breached and is pushing sketchy survey links through notifications. Do not click them. Here is what I saw.
 aliases: /2018/12/06/meetup-survey-link-scam/
 tags:
   - meetups

--- a/content/posts/2018/3/gaming-update-march-2018.md
+++ b/content/posts/2018/3/gaming-update-march-2018.md
@@ -1,6 +1,7 @@
 ---
 title: Gaming Update, March 2018
 date: 2018-03-04T21:23:00+00:00
+description: A gaming update on why I stepped away from World of Warcraft despite loving Legion, and what a healthier play session looks like.
 aliases: /2018/03/04/gaming-update-march-2018/
 tags:
   - gaming

--- a/content/posts/2018/3/wwdc-2018-social-booked.md
+++ b/content/posts/2018/3/wwdc-2018-social-booked.md
@@ -1,6 +1,7 @@
 ---
 title: WWDC 2018 Social, Booked
 date: 2018-03-13T19:39:04+00:00
+description: I am booked for WWDC week in San Jose, June 3rd to 7th. Not attending the conference itself, just the alternative events.
 aliases: /2018/03/13/wwdc-2018-social-booked/
 tags:
   - conferences

--- a/content/posts/2018/4/gaming-update-april-2018.md
+++ b/content/posts/2018/4/gaming-update-april-2018.md
@@ -1,6 +1,7 @@
 ---
 title: Gaming Update, April 2018
 date: 2018-04-05T00:57:29+00:00
+description: I quit World of Warcraft and immediately replaced it with Stardew Valley. An April update on the backlog I meant to be clearing.
 aliases: /2018/04/04/gaming-update-april-2018/
 tags:
   - gaming

--- a/content/posts/2018/4/hello-from-linode.md
+++ b/content/posts/2018/4/hello-from-linode.md
@@ -1,6 +1,7 @@
 ---
 title: Hello from Linode
 date: 2018-04-07T19:20:26+00:00
+description: This blog has moved to a new Linode server, closing out an old account and $40 a month. Still on WordPress, for now.
 aliases: /2018/04/07/hello-from-linode/
 tags:
   - devops

--- a/content/posts/2018/4/micro-manton.md
+++ b/content/posts/2018/4/micro-manton.md
@@ -1,6 +1,7 @@
 ---
 title: Micro.Manton
 date: 2018-04-13T18:56:35+00:00
+description: A joke at Manton Reece's expense. After Micro.blog and microcasts, the micro format has taken over the whole Reece household.
 aliases: /2018/04/13/micro-manton/
 ---
 

--- a/content/posts/2018/4/right-to-repair.md
+++ b/content/posts/2018/4/right-to-repair.md
@@ -1,6 +1,7 @@
 ---
 title: Right to Repair
 date: 2018-04-11T15:00:54+00:00
+description: iOS 11.3 disabled iPhone 8 screens installed by third-party repair shops. Another disappointment from Apple on right to repair.
 aliases: /2018/04/11/right-to-repair/
 tags:
   - apple

--- a/content/posts/2018/5/gaming-update-may-2018.md
+++ b/content/posts/2018/5/gaming-update-may-2018.md
@@ -1,6 +1,7 @@
 ---
 title: Gaming Update, May 2018
 date: 2018-05-18T15:15:35+00:00
+description: "A May gaming update: Stardew Valley winding down, a new Hearthstone expansion, and a second, better attempt at Zelda on Switch."
 aliases: /2018/05/18/gaming-update-may-2018/
 tags:
   - gaming

--- a/content/posts/2018/6/say-hello-at-wwdc.md
+++ b/content/posts/2018/6/say-hello-at-wwdc.md
@@ -1,6 +1,7 @@
 ---
 title: Say Hello at WWDC!
 date: 2018-06-02T01:49:44+00:00
+description: I will be in San Jose for WWDC week, hanging around AltConf and the other events rather than the conference itself.
 aliases: /2018/06/02/say-hello-at-wwdc/
 tags:
   - conferences

--- a/content/posts/2018/6/wwdc-2018-social-recap.md
+++ b/content/posts/2018/6/wwdc-2018-social-recap.md
@@ -1,6 +1,7 @@
 ---
 title: WWDC 2018 Social Recap
 date: 2018-06-09T02:49:05+00:00
+description: A recap of the social side of WWDC 2018, including a full cost breakdown of doing the week without a conference ticket.
 aliases: /2018/06/09/wwdc-2018-social-recap/
 tags:
   - conferences

--- a/content/posts/2018/7/back-to-full-time-at-indyhall.md
+++ b/content/posts/2018/7/back-to-full-time-at-indyhall.md
@@ -1,6 +1,7 @@
 ---
 title: Back to Full Time at IndyHall (video 5m)
 date: 2018-07-19T20:06:18+00:00
+description: A five-minute video on returning to IndyHall full time, and what makes Philadelphia's best coworking space worth the cost.
 aliases: /2018/07/19/back-to-full-time-at-indyhall/
 tags:
   - career

--- a/content/posts/2018/7/on-using-and-not-using-twitter.md
+++ b/content/posts/2018/7/on-using-and-not-using-twitter.md
@@ -1,6 +1,7 @@
 ---
 title: On Using and Not Using Twitter (video 8m)
 date: 2018-07-17T18:27:14+00:00
+description: An eight-minute video journal on my history with Twitter, my problems with the platform, and where I am headed instead.
 aliases: /2018/07/17/on-using-and-not-using-twitter/
 series:
   - Journals

--- a/content/posts/2018/8/hearthstone-is-too-expensive.md
+++ b/content/posts/2018/8/hearthstone-is-too-expensive.md
@@ -1,6 +1,7 @@
 ---
 title: Hearthstone is too expensive.
 date: 2018-08-06T13:25:31+00:00
+description: Hearthstone went from expensive to ludicrous over the past year, so I am out. A short video on what pushed me over the line.
 aliases: /2018/08/06/hearthstone-is-too-expensive/
 tags:
   - gaming

--- a/content/posts/2018/8/rainy-monday.md
+++ b/content/posts/2018/8/rainy-monday.md
@@ -1,6 +1,7 @@
 ---
 title: Rainy Monday
 date: 2018-08-13T19:09:29+00:00
+description: A short video journal. Rain washes out my ride to work, a Riker flashback lunch, and WoW patch day.
 aliases: /2018/08/13/rainy-monday/
 series:
   - Journals

--- a/content/posts/2018/9/elixirconf-2018-notes.md
+++ b/content/posts/2018/9/elixirconf-2018-notes.md
@@ -1,6 +1,7 @@
 ---
 title: ElixirConf 2018 Notes
 date: 2018-09-09T19:54:59+00:00
+description: Notes from ElixirConf 2018, and why Elixir is the ecosystem I settled on after years of sampling everything outside Apple's.
 aliases: /2018/09/09/elixirconf-2018-notes/
 tags:
   - conferences

--- a/content/posts/2018/9/gaming-update-september-2018.md
+++ b/content/posts/2018/9/gaming-update-september-2018.md
@@ -1,6 +1,7 @@
 ---
 title: Gaming Update, September 2018
 date: 2018-09-26T00:24:04+00:00
+description: A September gaming update. Officially done with Hearthstone, a rogue leveled to 120, and unsubscribing right as the raid dropped.
 aliases: /2018/09/26/gaming-update-september-2018/
 tags:
   - gaming

--- a/content/posts/2018/9/self-employment-estimate-numbers.md
+++ b/content/posts/2018/9/self-employment-estimate-numbers.md
@@ -1,6 +1,7 @@
 ---
 title: Self Employment Estimate Numbers
 date: 2018-09-04T20:22:16+00:00
+description: How I run the estimate numbers that tell me whether self-employment is on track, worked out in Soulver or any spreadsheet.
 aliases: /2018/09/04/self-employment-estimate-numbers/
 tags:
   - career

--- a/content/posts/2019/1/2018-retrospective-2019-goals.md
+++ b/content/posts/2019/1/2018-retrospective-2019-goals.md
@@ -1,6 +1,7 @@
 ---
 title: "2018 Retrospective; 2019 Goals"
 date: 2019-01-03T22:14:50-05:00
+description: A look back at my first full year of self-employment round two, what actually worked, and the goals I am setting for 2019.
 tags:
   - career
 ---

--- a/content/posts/2019/1/a-pivotal-year-for-the-mac-platform.md
+++ b/content/posts/2019/1/a-pivotal-year-for-the-mac-platform.md
@@ -1,6 +1,7 @@
 ---
 title: "A Pivotal Year for the Mac Platform"
 date: 2019-01-17T18:55:05-05:00
+description: The Mac Pro is finally due for a real refresh, and I have been waiting since 2011. Why 2019 decides my relationship with the platform.
 tags:
   - apple
 ---

--- a/content/posts/2019/1/designing-a-modern-swift-network-stack-video-and-slides/index.md
+++ b/content/posts/2019/1/designing-a-modern-swift-network-stack-video-and-slides/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Designing a Modern Swift Network Stack, Video and Slides"
 date: 2019-01-15T15:00:00-05:00
+description: Video and slides from my Philly CocoaHeads talk on building a Swift network layer that survives auth, token renewal, testing, and caching.
 tags:
   - ios
 ---

--- a/content/posts/2019/1/local-food-banks-need-help-during-shutdown.md
+++ b/content/posts/2019/1/local-food-banks-need-help-during-shutdown.md
@@ -1,6 +1,7 @@
 ---
 title: "Local Food Banks Need Help During Shutdown"
 date: 2019-01-11T15:55:55-05:00
+description: The government shutdown is pushing more families toward food banks. Philabundance could use your help right now.
 ---
 
 [Philabundance Blog](https://www.philabundance.org/on-the-menu-the-government-shut-down/) writes:

--- a/content/posts/2019/1/network-design-talk-at-philly-cocoaheads.md
+++ b/content/posts/2019/1/network-design-talk-at-philly-cocoaheads.md
@@ -1,6 +1,7 @@
 ---
 title: "Network Design Talk at Philly CocoaHeads"
 date: 2019-01-03T10:25:00-05:00
+description: I am giving a talk on designing a modern Swift network stack at Philly CocoaHeads on January 10th. Details and RSVP inside.
 tags:
   - ios
   - meetups

--- a/content/posts/2019/1/new-series-professional-ios-projects.md
+++ b/content/posts/2019/1/new-series-professional-ios-projects.md
@@ -1,6 +1,7 @@
 ---
 title: "New Series: Professional iOS Projects"
 date: 2019-01-08T12:40:03-05:00
+description: Kicking off a series on what separates a professional iOS project from a hobby one, starting with why I keep learning new languages.
 aliases: /posts/2019/1/new-series-anatomy-of-a-modern-ios-project/
 tags:
   - ios

--- a/content/posts/2019/1/new-year-new-site.md
+++ b/content/posts/2019/1/new-year-new-site.md
@@ -1,6 +1,7 @@
 ---
 title: "New Year, New Site"
 date: 2019-01-01T19:51:21-05:00
+description: I spent my holiday break rebuilding this site on Hugo, GitHub, and CircleCI, retiring the WordPress setup that came before it.
 aliases: /posts/2019/01/new-year-new-site/
 tags:
   - web-development

--- a/content/posts/2019/1/professional-ios-projects-code-consistency-with-swiftlint/index.md
+++ b/content/posts/2019/1/professional-ios-projects-code-consistency-with-swiftlint/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Code Consistency with SwiftLint"
 date: 2019-01-24T12:00:00-05:00
+description: Why consistent code style matters more than which style you pick, and how SwiftLint keeps an iOS project honest about it.
 aliases: /posts/2019/1/anatomy-of-a-modern-ios-project-code-consistency-with-swiftlint/
 tags:
   - ios

--- a/content/posts/2019/1/professional-ios-projects-the-readme-file.md
+++ b/content/posts/2019/1/professional-ios-projects-the-readme-file.md
@@ -1,6 +1,7 @@
 ---
 title: "The README File"
 date: 2019-01-08T12:51:32-05:00
+description: The README is the first thing anyone meets in your project, including future you. Here is what I make sure mine covers.
 aliases: /posts/2019/1/anatomy-of-a-modern-ios-project-the-readme-file/
 tags:
   - software-craft

--- a/content/posts/2019/1/registered-for-emerging-technologies-for-the-enterprise.md
+++ b/content/posts/2019/1/registered-for-emerging-technologies-for-the-enterprise.md
@@ -1,6 +1,7 @@
 ---
 title: "Registered for Emerging Technologies for the Enterprise 2019"
 date: 2019-01-22T12:35:09-05:00
+description: I grabbed early bird tickets for Emerging Technologies for the Enterprise 2019, and why I like sampling topics outside my iOS circles.
 tags:
   - conferences
 ---

--- a/content/posts/2019/1/terminal-tips-quickly- launch-into-servers-and-services/index.md
+++ b/content/posts/2019/1/terminal-tips-quickly- launch-into-servers-and-services/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Terminal Tip: Quickly Launch Into Servers and Services"
 date: 2019-01-12T12:00:00-05:00
+description: "A Terminal tip: use profiles to open a window that jumps to a project folder, starts a local server, and color codes itself."
 tags:
   - devops
 ---

--- a/content/posts/2019/10/available-for-consulting-web-and-mobile-elixir-and-ios.md
+++ b/content/posts/2019/10/available-for-consulting-web-and-mobile-elixir-and-ios.md
@@ -1,6 +1,7 @@
 ---
 title: "Available for Consulting: Web and Mobile, Elixir and iOS"
 date: 2019-10-24T13:16:52-04:00
+description: Some projects were postponed, so I have Elixir and iOS consulting availability opening up for November and December.
 tags:
   - consulting
 ---

--- a/content/posts/2019/10/club-house-hosting-dev-diary-1.md
+++ b/content/posts/2019/10/club-house-hosting-dev-diary-1.md
@@ -1,6 +1,7 @@
 ---
 title: "Club House Hosting Dev Diary 1: Some Introductions"
 date: 2019-10-21T11:08:21-04:00
+description: The first dev diary video for Club House Hosting, with introductions to me, the project, and the timeline I have in mind.
 tags:
   - side-projects
 ---

--- a/content/posts/2019/10/full-time-spaceship-employees-only.md
+++ b/content/posts/2019/10/full-time-spaceship-employees-only.md
@@ -1,6 +1,7 @@
 ---
 title: "Full Time Spaceship Employees Only"
 date: 2019-10-22T17:22:29-04:00
+description: Apple's documentation problem is not only about money. Its unwillingness to hire remote writers is the factor nobody brings up.
 tags:
   - apple
 ---

--- a/content/posts/2019/11/club-house-hosting-dev-diary-2.md
+++ b/content/posts/2019/11/club-house-hosting-dev-diary-2.md
@@ -1,6 +1,7 @@
 ---
 title: "Club House Hosting Dev Diary 2: A Tour of UI Sketches"
 date: 2019-11-04T13:42:04-05:00
+description: Dev diary two for Club House Hosting, touring the early UI sketches and what I plan to tackle this week.
 tags:
   - side-projects
 ---

--- a/content/posts/2019/12/gaming-update-december-2019.md
+++ b/content/posts/2019/12/gaming-update-december-2019.md
@@ -1,6 +1,7 @@
 ---
 title: "Gaming Update, December 2019"
 date: 2019-12-21T16:44:31-05:00
+description: What I have been playing over the holiday break, including WoW Classic on an RP-PvP server and the Link's Awakening remake.
 tags:
   - gaming
 ---

--- a/content/posts/2019/12/website-revamp.md
+++ b/content/posts/2019/12/website-revamp.md
@@ -1,6 +1,7 @@
 ---
 title: "Website Revamp"
 date: 2019-12-17T14:01:51-05:00
+description: I rebuilt this site's Hugo theme from scratch over a few days, added a bit of branding, and stood up a new For Hire section.
 tags:
   - web-development
 ---

--- a/content/posts/2019/2/gaming-update.md
+++ b/content/posts/2019/2/gaming-update.md
@@ -1,6 +1,7 @@
 ---
 title: "Gaming Update, February 2019"
 date: 2019-02-13T12:00:00-05:00
+description: What I am playing in February 2019, mostly Civilization VI and learning its mechanics ahead of the Gathering Storm expansion.
 tags:
   - gaming
 ---

--- a/content/posts/2019/2/professional-ios-projects-code-documentation/index.md
+++ b/content/posts/2019/2/professional-ios-projects-code-documentation/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Code Documentation"
 date: 2019-02-19T10:00:00-05:00
+description: "Professional iOS projects document two ways: inline comments on the types, and guides that explain the thinking above them."
 tags:
   - software-craft
 ---

--- a/content/posts/2019/3/group-leadership-club.md
+++ b/content/posts/2019/3/group-leadership-club.md
@@ -1,6 +1,7 @@
 ---
 title: "New Project: Group Leadership Club"
 date: 2019-03-07T21:19:13-05:00
+description: Announcing Group Leadership Club, a site of articles and a forum for people who start, run, and sustain technical meetup groups.
 tags:
   - side-projects
   - meetups

--- a/content/posts/2019/3/the-common-good-book/index.md
+++ b/content/posts/2019/3/the-common-good-book/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Book: The Common Good"
 date: 2019-03-18T10:00:00-05:00
+description: Notes on Robert Reich's The Common Good, a case that a shared moral imagination is the essence of any functioning society.
 tags:
   - books
   - reviews

--- a/content/posts/2019/4/blog-update-video.md
+++ b/content/posts/2019/4/blog-update-video.md
@@ -1,6 +1,7 @@
 ---
 title: "Video: Blog Update, April 2019"
 date: 2019-04-22T09:00:00-05:00
+description: A short video update on the blog. No big announcements, just where things stand in April 2019.
 series:
   - Journals
 ---

--- a/content/posts/2019/4/philly-elixir-meetup-reboot.md
+++ b/content/posts/2019/4/philly-elixir-meetup-reboot.md
@@ -1,6 +1,7 @@
 ---
 title: "Philly Elixir Meetup is Rebooting"
 date: 2019-04-22T10:00:00-05:00
+description: The Philly Elixir Meetup is coming back after too long a hiatus. First meeting is May 6th at PromptWorks. Come say hello.
 tags:
   - meetups
   - elixir

--- a/content/posts/2019/5/thoughts-on-mac-pros-at-wwdc/index.md
+++ b/content/posts/2019/5/thoughts-on-mac-pros-at-wwdc/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Thoughts on Mac Pros at WWDC"
 date: 2019-05-07T15:48:04-04:00
+description: Rereading Apple's 2017 Mac roundtable transcript, and why blaming pros for moving to laptops ignores Apple's own neglect.
 tags:
   - apple
   - hardware

--- a/content/posts/2019/6/macpro-reactions.md
+++ b/content/posts/2019/6/macpro-reactions.md
@@ -1,6 +1,7 @@
 ---
 title: "MacPro Reactions"
 date: 2019-06-04T19:41:48-04:00
+description: The 2019 Mac Pro is technically everything I asked for, from expandable RAM to PCI slots. My reactions after the WWDC reveal.
 tags:
   - apple
   - hardware

--- a/content/posts/2019/6/the-great-monitor-search-continues.md
+++ b/content/posts/2019/6/the-great-monitor-search-continues.md
@@ -1,6 +1,7 @@
 ---
 title: "The Great Monitor Search Continues"
 date: 2019-06-24T19:30:40-04:00
+description: The LG 49-inch UltraWide is cool but fights macOS. Why I am trading screen real estate for the 4K UltraFine instead.
 tags:
   - apple
   - hardware

--- a/content/posts/2019/7/july-recap.md
+++ b/content/posts/2019/7/july-recap.md
@@ -1,6 +1,7 @@
 ---
 title: "A Smorgasbord of Updates, July 2019"
 date: 2019-07-29T15:12:22-04:00
+description: "A July catch-all: a shore vacation, turning 40, quiet client work, and the new project we kick-started at the end of the month."
 series:
   - Journals
 ---

--- a/content/posts/2019/8/a-month-with-the-2019-23.7-inch-lg-ultrafine-4k-display/index.md
+++ b/content/posts/2019/8/a-month-with-the-2019-23.7-inch-lg-ultrafine-4k-display/index.md
@@ -1,6 +1,7 @@
 ---
 title: "A Month with the 2019 23.7-inch LG UltraFine 4K Display"
 date: 2019-08-01T20:00:00-04:00
+description: One month with the 23.7-inch LG UltraFine 4K after returning the UltraWide, and what retina and native controls actually buy you.
 tags:
   - apple
   - hardware

--- a/content/posts/2019/8/first-elixirconf-and-then-azeroth.md
+++ b/content/posts/2019/8/first-elixirconf-and-then-azeroth.md
@@ -1,6 +1,7 @@
 ---
 title: "First ElixirConf, and Then Azeroth"
 date: 2019-08-23T15:20:41-04:00
+description: Heading to my first ElixirConf for four days of workshops and talks, including LiveView. Then some well-earned time in Azeroth.
 tags:
   - conferences
   - elixir

--- a/content/posts/2019/8/if-flying-print-out-macbook-battery-status/index.md
+++ b/content/posts/2019/8/if-flying-print-out-macbook-battery-status/index.md
@@ -1,6 +1,7 @@
 ---
 title: "If Flying, Print Out MacBook Battery Status"
 date: 2019-08-23T21:43:50-04:00
+description: The FAA banned certain recalled-battery MacBook Pros from flights. Check your serial number and bring proof to the airport.
 tags:
   - apple
 ---

--- a/content/posts/2019/8/on-conferences.md
+++ b/content/posts/2019/8/on-conferences.md
@@ -1,6 +1,7 @@
 ---
 title: "On Conferences"
 date: 2019-08-14T11:23:59-04:00
+description: "Two conference rules I would love to try someday: everyone presents something, and no laptops or phones in the hall."
 aliases: /posts/2019/78/on-conferences/
 tags:
   - conferences

--- a/content/posts/2019/9/my-new-project-club-house-hosting.md
+++ b/content/posts/2019/9/my-new-project-club-house-hosting.md
@@ -1,6 +1,7 @@
 ---
 title: "My New Project: Club House Hosting"
 date: 2019-09-17T11:30:26-04:00
+description: Introducing Club House Hosting, a platform for group organizers to run their own site with event RSVPs and member directories.
 tags:
   - side-projects
 ---

--- a/content/posts/2020/1/2019-accomplishments-and-2020-goals.md
+++ b/content/posts/2020/1/2019-accomplishments-and-2020-goals.md
@@ -1,6 +1,7 @@
 ---
 title: "2019 Accomplishments and 2020 Goals"
 date: 2020-01-14T12:22:38-05:00
+description: Looking back at how my 2019 goals actually went, and setting the ones I want to chase through 2020.
 tags:
   - career
 ---

--- a/content/posts/2020/1/consulting-availability.md
+++ b/content/posts/2020/1/consulting-availability.md
@@ -1,6 +1,7 @@
 ---
 title: "iOS and Web Consulting Availability"
 date: 2020-01-03T10:53:23-05:00
+description: I have consulting availability opening up. Here are the kinds of iOS, Elixir, and CI projects that tend to be a good fit for me.
 tags:
   - consulting
 ---

--- a/content/posts/2020/10/finding-volunteers/index.md
+++ b/content/posts/2020/10/finding-volunteers/index.md
@@ -6,7 +6,7 @@ tags:
   - meetups
 ---
 
-> This blog post was orientally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
+> This blog post was originally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
 
 One of the biggest milestones of any meetup or community is when the group evolves beyond: "Mike's group" to "our group". (Substitute your own name for mine. 😀)
 

--- a/content/posts/2020/10/finding-volunteers/index.md
+++ b/content/posts/2020/10/finding-volunteers/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Finding Volunteers for Your Meetup Group"
 date: 2020-10-19T10:00:27-04:00
-description: The easiest way to find volunteers for your meetup group is to ask for help. Be specific and define meaningful, approachable tasks that are easy for group regulars to take on.
+description: The easiest way to find meetup volunteers is to ask. Be specific, and define approachable tasks a group regular can take on.
 tags:
   - meetups
 ---

--- a/content/posts/2020/10/look-back-oct-11/index.md
+++ b/content/posts/2020/10/look-back-oct-11/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Look Back: Week Ending October 11th"
 date: 2020-10-12T09:53:50-04:00
-description: Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+description: A weekly look back. A big Guildflow landing page update, and a Swoosh fork adding Postmark broadcast message streams.
 series:
   - Journals
 ---

--- a/content/posts/2020/10/look-back-oct-11/index.md
+++ b/content/posts/2020/10/look-back-oct-11/index.md
@@ -6,7 +6,7 @@ series:
   - Journals
 ---
 
-Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+A good week for the work other people can see, and for a fair bit they never will. Adding it all up from last week.
 
 ## [Guildflow](/projects/guildflow/)
 

--- a/content/posts/2020/10/look-back-oct-18/index.md
+++ b/content/posts/2020/10/look-back-oct-18/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Look Back: Week Ending October 18th"
 date: 2020-10-19T10:21:06-04:00
-description: Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+description: A weekly look back. My Postmark broadcast pull request merged into Swoosh, and an Add to Calendar feature for events.
 series:
   - Journals
 ---

--- a/content/posts/2020/10/look-back-oct-18/index.md
+++ b/content/posts/2020/10/look-back-oct-18/index.md
@@ -6,7 +6,7 @@ series:
   - Journals
 ---
 
-Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+Some weeks a thing you've been chipping away at gets merged and the whole list feels lighter. Last week was one of those.
 
 ## [Guildflow](/projects/guildflow/)
 

--- a/content/posts/2020/10/look-back-oct-25/index.md
+++ b/content/posts/2020/10/look-back-oct-25/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Look Back: Week Ending October 25th"
 date: 2020-10-25T19:12:02-04:00
-description: Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+description: A weekly look back. Podcast marketing experiments, a screenshot gallery, and what a community manager taught me.
 series:
   - Journals
 ---

--- a/content/posts/2020/10/look-back-oct-25/index.md
+++ b/content/posts/2020/10/look-back-oct-25/index.md
@@ -6,7 +6,7 @@ series:
   - Journals
 ---
 
-Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+A quieter week for Guildflow, since a new full time client project started up and took most of the oxygen. Here's how it shook out.
 
 ## [Guildflow](/projects/guildflow/)
 

--- a/content/posts/2020/10/postmark-broadcast-via-elixir-swoosh/index.md
+++ b/content/posts/2020/10/postmark-broadcast-via-elixir-swoosh/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Using Postmark's new Broadcast Email Stream via Elixir and Swoosh"
 date: 2020-10-12T13:51:26-04:00
-description: In advance of adding some new broadcast email features to Guildflow I've built some additions to the Swoosh Elixir email library that allow one to use the new broadcast message stream feature of Postmark.
+description: I added support for Postmark's new broadcast message stream to the Swoosh Elixir email library. Here is how to use it.
 images:
   - posts/2020/10/postmark-broadcast-via-elixir-swoosh/thumb.jpg
 tags:

--- a/content/posts/2020/11/look-back-nov-1/index.md
+++ b/content/posts/2020/11/look-back-nov-1/index.md
@@ -6,7 +6,7 @@ series:
   - Journals
 ---
 
-Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+Mostly a marketing week. Most of what I did was about getting Guildflow in front of people rather than adding anything to it.
 
 ## [Guildflow](/projects/guildflow/)
 

--- a/content/posts/2020/11/look-back-nov-1/index.md
+++ b/content/posts/2020/11/look-back-nov-1/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Look Back: Week Ending November 1st"
 date: 2020-11-02T18:17:25-05:00
-description: Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+description: A weekly look back. Sponsoring the Release Notes podcast, a screenshot gallery on the marketing site, and a Philly GDG demo.
 series:
   - Journals
 ---

--- a/content/posts/2020/11/look-back-nov-22/index.md
+++ b/content/posts/2020/11/look-back-nov-22/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Look Back: Week Ending November 22nd"
 date: 2020-11-22T19:50:10-05:00
-description: Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+description: A twofer look back. A pitch for Guildflow messaging behaviors, mastermind notes, and a quiet stretch ahead through the holidays.
 series:
   - Journals
 ---

--- a/content/posts/2020/11/look-back-nov-22/index.md
+++ b/content/posts/2020/11/look-back-nov-22/index.md
@@ -6,8 +6,6 @@ series:
   - Journals
 ---
 
-Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
-
 I missed last week's update so consider this one a twofer.
 
 ## [Guildflow](/projects/guildflow/)

--- a/content/posts/2020/11/look-back-nov-8/index.md
+++ b/content/posts/2020/11/look-back-nov-8/index.md
@@ -6,7 +6,7 @@ series:
   - Journals
 ---
 
-Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+A short list this week. Client work took nearly all of it, and honestly that's fine.
 
 ## [Guildflow](/projects/guildflow/)
 

--- a/content/posts/2020/11/look-back-nov-8/index.md
+++ b/content/posts/2020/11/look-back-nov-8/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Look Back: Week Ending November 8th"
 date: 2020-11-09T21:18:28-05:00
-description: Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+description: A weekly look back. Shipping Add to Calendar, renewing SSL certs, the last Android Book Club, and a new 16-inch MacBook Pro.
 series:
   - Journals
 ---

--- a/content/posts/2020/12/look-back-dec-13/index.md
+++ b/content/posts/2020/12/look-back-dec-13/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Look Back: Week Ending December 13th"
 date: 2020-12-13T15:48:20-05:00
-description: A terse review of what I've been up to.
+description: A look back covering the Ethical Ads campaign results, deployment automation for Guildflow, and where things stand.
 series:
   - Journals
 ---

--- a/content/posts/2020/12/look-back-dec-27/index.md
+++ b/content/posts/2020/12/look-back-dec-27/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Look Back: Week Ending December 27th"
 date: 2020-12-29T17:41:34-05:00
-description: A terse review of what I've been up to.
+description: A lighter vacation-week look back, with group messaging progress in Guildflow and some early brainstorming on 2021 goals.
 series:
   - Journals
 ---

--- a/content/posts/2020/12/terraform-on-linode-notes/index.md
+++ b/content/posts/2020/12/terraform-on-linode-notes/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Terraform on Linode Notes"
 date: 2020-12-23T05:54:53-05:00
-description: Over vacation I worked through a small project to use Terraform on Linode to provision a new webserver for my personal website. The following is a collection of notes and resources from the experience.
+description: Notes and resources from a vacation project using Terraform on Linode to provision a new webserver for this site.
 tags:
   - devops
 ---

--- a/content/posts/2020/3/consulting-availability.md
+++ b/content/posts/2020/3/consulting-availability.md
@@ -1,6 +1,7 @@
 ---
 title: "Consulting Availability"
 date: 2020-03-20T11:39:29-04:00
+description: My client project wraps April 1st, so I have consulting availability again. Here is the kind of work that fits me best.
 tags:
   - consulting
 ---

--- a/content/posts/2020/3/meetup-finds-new-owners-and-i-welcome-the-competition.md
+++ b/content/posts/2020/3/meetup-finds-new-owners-and-i-welcome-the-competition.md
@@ -1,6 +1,7 @@
 ---
 title: "Meetup Finds New Owners and I Welcome the Competition"
 date: 2020-03-31T18:11:15-04:00
+description: Meetup has been sold again. Why I welcome the competition, and how it relates to the IndieWeb-minded alternative I am building.
 tags:
   - meetups
 ---

--- a/content/posts/2020/3/renaissance-man.md
+++ b/content/posts/2020/3/renaissance-man.md
@@ -1,6 +1,7 @@
 ---
 title: "Renaissance Man"
 date: 2020-03-16T15:39:04-04:00
+description: Bouncing between iOS, Go, C, and Kotlin on one client project, and why I think good programmers are better off knowing many languages.
 tags:
   - software-craft
 ---

--- a/content/posts/2020/3/spinning-plates.md
+++ b/content/posts/2020/3/spinning-plates.md
@@ -1,6 +1,7 @@
 ---
 title: "Spinning Plates"
 date: 2020-03-01T22:06:55-05:00
+description: A personal update on new iOS contract work, side project progress, and the plates I am trying to keep spinning this month.
 series:
   - Journals
 ---

--- a/content/posts/2020/3/things-change-fast.md
+++ b/content/posts/2020/3/things-change-fast.md
@@ -1,6 +1,7 @@
 ---
 title: "Things Change Fast"
 date: 2020-03-26T10:54:14-04:00
+description: My personal record of how fast early 2020 changed, from canceled conference trips to a household settling into lockdown.
 series:
   - Journals
 ---

--- a/content/posts/2020/3/working-with-time-zones-in-an-elixir-phoenix-app/index.md
+++ b/content/posts/2020/3/working-with-time-zones-in-an-elixir-phoenix-app/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Video: Working With Time Zones in an Elixir Phoenix App"
 date: 2020-03-19T11:14:21-04:00
+description: Talk video and slides on what time zones are, how Elixir models them, and strategies for handling them in a Phoenix app backed by Ecto.
 tags:
   - elixir
 ---

--- a/content/posts/2020/3/zoom-google-hangout-alternatives.md
+++ b/content/posts/2020/3/zoom-google-hangout-alternatives.md
@@ -1,6 +1,7 @@
 ---
 title: "Zoom / Google Hangout Alternatives"
 date: 2020-03-27T14:02:41-04:00
+description: Zoom and Google Hangouts both leave me uneasy. A running list of video conferencing alternatives that better respect user privacy.
 tags:
   - privacy
 ---

--- a/content/posts/2020/4/april-book-update.md
+++ b/content/posts/2020/4/april-book-update.md
@@ -1,6 +1,7 @@
 ---
 title: "April Book Update"
 date: 2020-04-16T09:54:46-04:00
+description: "Three books worth your time, from a slow reader: Snowden's Permanent Record, Swift for Good, and Mike Monteiro's Ruined by Design."
 tags:
   - books
 ---

--- a/content/posts/2020/4/baseball.md
+++ b/content/posts/2020/4/baseball.md
@@ -1,6 +1,7 @@
 ---
 title: "Baseball"
 date: 2020-04-18T14:32:59-04:00
+description: With the season on hold, I have been working through Ken Burns' Baseball documentary. The passage that opens it still gets me.
 ---
 
 > It is played everywhere: in parks and playgrounds, prison yards, in back alleys and farmers’ fields; by small boys and old men, raw amateurs and millionaire professionals. It is a leisurely game that demands blinding speed; the only game in which the defense has the ball. It follows the seasons, beginning each year with the fond expectancy of springtime and ending with the hard facts of autumn.

--- a/content/posts/2020/4/clubhouse-public-alpha/index.md
+++ b/content/posts/2020/4/clubhouse-public-alpha/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Clubhouse Public Alpha"
 date: 2020-04-21T10:50:28-04:00
+description: After more than a year of side project nights, the first public alpha of Clubhouse, my IndieWeb-minded alternative to Meetup, is out.
 tags:
   - side-projects
 ---

--- a/content/posts/2020/4/how-i-decided-to-build-clubhouse.md
+++ b/content/posts/2020/4/how-i-decided-to-build-clubhouse.md
@@ -1,6 +1,7 @@
 ---
 title: "Video: How I Decided to Build Clubhouse (6m)"
 date: 2020-04-24T11:32:08-04:00
+description: A six-minute video on how I landed on Clubhouse as my side project, and what made the meetup problem worth solving.
 tags:
   - side-projects
 ---

--- a/content/posts/2020/4/nurturing-your-community-during-lock-down.md
+++ b/content/posts/2020/4/nurturing-your-community-during-lock-down.md
@@ -1,6 +1,7 @@
 ---
 title: "Video: Nurturing Your Community During Lock Down (7m)"
 date: 2020-04-27T14:50:16-04:00
+description: A seven-minute video with ideas for keeping a meetup group connected while everyone is stuck at home.
 tags:
   - meetups
 ---

--- a/content/posts/2020/4/open-office-hours.md
+++ b/content/posts/2020/4/open-office-hours.md
@@ -1,6 +1,7 @@
 ---
 title: "Open Office Hours"
 date: 2020-04-02T10:25:12-04:00
+description: I am opening free one-hour office hours for casual consults on Swift, Elixir, testing, CI, and static sites. Grab a slot.
 tags:
   - consulting
 ---

--- a/content/posts/2020/4/personal-lockdown-update.md
+++ b/content/posts/2020/4/personal-lockdown-update.md
@@ -1,7 +1,7 @@
 ---
 title: "Personal Lockdown Update"
 date: 2020-04-30T09:57:51-04:00
-description: Again, I'm thankful for my privilege. I have savings to live off for a while. But let's not forget, there are people out there starving and this program right now is bringing no relief.
+description: A lockdown check-in. I am thankful for savings and privilege, and mindful that this relief program is reaching nobody yet.
 series:
   - Journals
 ---

--- a/content/posts/2020/4/putting-zoom-in-quarantine.md
+++ b/content/posts/2020/4/putting-zoom-in-quarantine.md
@@ -1,6 +1,7 @@
 ---
 title: "Putting Zoom in Quarantine"
 date: 2020-04-09T16:03:22-04:00
+description: An update on my hunt for a Zoom alternative, including how Jitsi and Whereby actually fared with my Elixir meetup group.
 tags:
   - privacy
 ---

--- a/content/posts/2020/4/quick-thoughts-on-user-testing.md
+++ b/content/posts/2020/4/quick-thoughts-on-user-testing.md
@@ -1,6 +1,7 @@
 ---
 title: "Video: Quick Thoughts on User Testing (5m)"
 date: 2020-04-23T10:50:17-04:00
+description: A five-minute video on running cheap, do-it-yourself usability tests, plus the script I used on my own project.
 tags:
   - side-projects
 ---

--- a/content/posts/2020/4/swift-uint-vs-int.md
+++ b/content/posts/2020/4/swift-uint-vs-int.md
@@ -1,6 +1,7 @@
 ---
 title: "Swift UInt vs Int"
 date: 2020-04-09T15:23:36-04:00
+description: Why I am tempted to return Swift's UInt for values that can never be negative, even though the community leans on Int.
 tags:
   - ios
 ---

--- a/content/posts/2020/4/video-an-introduction-to-elixir/index.md
+++ b/content/posts/2020/4/video-an-introduction-to-elixir/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Video: An Introduction to Elixir"
 date: 2020-04-14T08:46:05-04:00
+description: Talk video and slides introducing Elixir, covering the language basics, what it is good for, and why it fits certain problems well.
 tags:
   - elixir
 ---

--- a/content/posts/2020/4/video-book-review:-ruined-by-design-by-mike-monteiro.md
+++ b/content/posts/2020/4/video-book-review:-ruined-by-design-by-mike-monteiro.md
@@ -1,6 +1,7 @@
 ---
 title: "Video Book Review: Ruined by Design by Mike Monteiro (5m)"
 date: 2020-04-29T09:58:03-04:00
+description: A five-minute video review of Ruined by Design, Mike Monteiro's case that designers are responsible for what they build.
 tags:
   - books
   - reviews

--- a/content/posts/2020/5/how-much-does-it-cost-to-build-an-ios-app/index.md
+++ b/content/posts/2020/5/how-much-does-it-cost-to-build-an-ios-app/index.md
@@ -1,7 +1,7 @@
 ---
 title: "How Much Does It Cost to Build an iOS App?"
 date: 2020-05-17T16:26:38-04:00
-description: Most quality iOS apps cost between $100,000 to $1,000,000 to build. Some apps will be less and some more. If you're looking for an app built with great design, superior development, and clever marketing though, it will be somewhere in that range.
+description: Most quality iOS apps cost between $100,000 and $1,000,000 to build. Where that range comes from, and what moves you inside it.
 images:
   - posts/2020/5/how-much-does-it-cost-to-build-an-ios-app/thumb.jpg
 tags:

--- a/content/posts/2020/6/an-android-book-club-for-ios-developers/index.md
+++ b/content/posts/2020/6/an-android-book-club-for-ios-developers/index.md
@@ -1,7 +1,7 @@
 ---
 title: "An Android Book Club for iOS Developers"
 date: 2020-06-30T10:03:23-04:00
-description: I am hoping to attract current iOS developers who are looking to expand their knowledge and use their current experiences with Swift and iOS to help shape the conversations at the weekly meetings.
+description: An Android book club aimed at iOS developers, using what you already know from Swift and iOS to shape the conversation.
 images:
   - posts/2020/6/an-android-book-club-for-ios-developers/thumb.jpeg
 tags:

--- a/content/posts/2020/6/apple-eu-antitrust/index.md
+++ b/content/posts/2020/6/apple-eu-antitrust/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Apple's EU Antitrust Investigation is Long Overdue"
 date: 2020-06-16T17:58:01-04:00
+description: The EU opened formal antitrust investigations into Apple's App Store rules. My take on why the scrutiny is long overdue.
 tags:
   - apple
 ---

--- a/content/posts/2020/6/clubhouse-is-now-guildflow/index.md
+++ b/content/posts/2020/6/clubhouse-is-now-guildflow/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Clubhouse is Now Guildflow"
 date: 2020-06-19T11:38:06-04:00
+description: My meetup project has a new name. Why Campfire and Clubhouse did not survive the trademark checks, and what Guildflow means.
 tags:
   - side-projects
 ---

--- a/content/posts/2020/6/how-i-use-omnifocus-to-track-tasks/index.md
+++ b/content/posts/2020/6/how-i-use-omnifocus-to-track-tasks/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Video: How I Use OmniFocus to Track Tasks (12m)"
 date: 2020-06-10T09:59:22-04:00
-description: I've been a fan of Getting Things Done and a casual user of OmniFocus for years, mostly focusing on long term projects. For weekly stuff I used to do a manual list in Bear but a few weeks ago I took the time to see if I could make OmniFocus work for my weekly list, and so far it's working out great. This video is a review of what's changed.
+description: A 12-minute video on how I finally made OmniFocus work for my weekly task list, not just the long term projects.
 images:
   - posts/2020/6/how-i-use-omnifocus-to-track-tasks/this-week-perspective.png
 tags:

--- a/content/posts/2020/6/how-to-brainstorm-presentation-topics-for-your-events/index.md
+++ b/content/posts/2020/6/how-to-brainstorm-presentation-topics-for-your-events/index.md
@@ -6,7 +6,7 @@ tags:
   - meetups
 ---
 
-> This blog post was orientally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
+> This blog post was originally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
 
 In my experience running meetup groups for over a decade, the social aspect or hallway conversations can sometimes be the most beneficial aspects of an event yet to hold **an event without a speaker or topic can usually lead to an empty RSVP list**.
 

--- a/content/posts/2020/7/finding-speakers-to-present-at-your-event/index.md
+++ b/content/posts/2020/7/finding-speakers-to-present-at-your-event/index.md
@@ -6,7 +6,7 @@ tags:
   - meetups
 ---
 
-> This blog post was orientally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
+> This blog post was originally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
 
 Helping to organize a meetup group can be extremely rewarding. I've been running various groups for over 10 years now and I only regret not getting starting sooner. Still, there is not much to love in the minutia of monthly tasks to keep everything going.
 

--- a/content/posts/2020/7/webkit-feature-development-and-privacy/index.md
+++ b/content/posts/2020/7/webkit-feature-development-and-privacy/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Is WebKit Sabotaging the Future of the Open Web?"
 date: 2020-07-06T17:10:19-04:00
-description: Just to be clear, I am a privacy advocate. I use DuckDuckGo. I use Firefox. I block ads. I encrypt my DNS lookups. I'm building a privacy-focused tool for meetups. And with all that said, this worries me.
+description: I am a privacy advocate by every measure, and WebKit's approach to new web features still worries me. Here is why.
 tags:
   - privacy
   - web-development

--- a/content/posts/2020/8/actionable-ideas-how-meetups-can-evolve-when-forced-online-only/index.md
+++ b/content/posts/2020/8/actionable-ideas-how-meetups-can-evolve-when-forced-online-only/index.md
@@ -8,7 +8,7 @@ tags:
   - meetups
 ---
 
-> This blog post was orientally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
+> This blog post was originally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
 
 Today I recorded some thoughts regarding the challenges meetups are facing as they've been forced online and ideas how those challenges can be met.
 

--- a/content/posts/2020/8/evolve-or-die-its-time-to-rethink-meetup-groups/index.md
+++ b/content/posts/2020/8/evolve-or-die-its-time-to-rethink-meetup-groups/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Evolve or Die: It's Time to Rethink Meetup Groups"
 date: 2020-08-30T14:10:57-04:00
-description: While meetups have lots of individual and social benefits, many have not evolved and are on a declining trajectory. In today’s video we’ll ponder as to the causes of this decline and how you can evolve your own meetup group to not only survive, but thrive.
+description: Many meetup groups have not evolved and are in decline. A video on why that happens and how to help your own group thrive.
 images:
   - posts/2020/8/evolve-or-die-its-time-to-rethink-meetup-groups/thumb.jpeg
 tags:

--- a/content/posts/2020/8/evolve-or-die-its-time-to-rethink-meetup-groups/index.md
+++ b/content/posts/2020/8/evolve-or-die-its-time-to-rethink-meetup-groups/index.md
@@ -8,7 +8,7 @@ tags:
   - meetups
 ---
 
-> This blog post was orientally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
+> This blog post was originally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
 
 {{< video filename="evolve_or_die _its_time_to_rethink_meetup_groups.mp4" youtube="5gaZGDXWAKY" title="Evolve or Die: It's Time to Rethink Meetup Groups" >}}
 

--- a/content/posts/2020/9/building-screencasts/index.md
+++ b/content/posts/2020/9/building-screencasts/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Screencast about Building Screencasts: How I Built the Guildflow 70-second Introduction Video"
 date: 2020-09-03T12:12:44-04:00
-description: I generalize the term screencast here as any video where you see primarily a computer or user interface, with a voice and optional video feed of a person doing some kind of demonstration.
+description: How I built the 70-second Guildflow introduction video, and what I have learned about making screencasts in general.
 images:
   - posts/2020/9/building-screencasts/thumb.jpeg
 tags:

--- a/content/posts/2020/9/goal-oriented-side-event-ideas/index.md
+++ b/content/posts/2020/9/goal-oriented-side-event-ideas/index.md
@@ -6,7 +6,7 @@ tags:
   - meetups
 ---
 
-> This blog post was orientally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
+> This blog post was originally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
 
 I'm a firm believer that going forward, [successful technical meetup groups need to evolve past the once-a-month event style](/posts/2020/8/evolve-or-die-its-time-to-rethink-meetup-groups/) to more of an ongoing community presence, with smaller goal-oriented events happening more often. I believe it is through these events the social connections that ultimately lead to a successful community are solidified.
 

--- a/content/posts/2020/9/look-back-sept-13/index.md
+++ b/content/posts/2020/9/look-back-sept-13/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Look Back: Week Ending September 13th"
 date: 2020-09-13T16:20:17-04:00
-description: Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+description: A weekly look back. A Guildflow release with bug fixes and security updates, plus progress on custom pages and navigation.
 series:
   - Journals
 ---

--- a/content/posts/2020/9/look-back-sept-13/index.md
+++ b/content/posts/2020/9/look-back-sept-13/index.md
@@ -6,7 +6,7 @@ series:
   - Journals
 ---
 
-Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+It's easy to fixate on the one big feature that didn't quite make the deployment. Adding up the rest of the week tells a much better story.
 
 ## [Guildflow](/projects/guildflow/)
 

--- a/content/posts/2020/9/look-back-sept-20/index.md
+++ b/content/posts/2020/9/look-back-sept-20/index.md
@@ -6,7 +6,7 @@ series:
   - Journals
 ---
 
-Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+The most consequential thing I did last week was hit a wall, one that's going to change how I design the UI. Here's that and everything else.
 
 ## [Guildflow](/projects/guildflow/)
 

--- a/content/posts/2020/9/look-back-sept-20/index.md
+++ b/content/posts/2020/9/look-back-sept-20/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Look Back: Week Ending September 20th"
 date: 2020-09-21T11:36:54-04:00
-description: Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+description: A weekly look back. A draft terms of service, editable navigation running into UI problems, and a move to Fathom Analytics.
 series:
   - Journals
 ---

--- a/content/posts/2020/9/look-back-sept-27/index.md
+++ b/content/posts/2020/9/look-back-sept-27/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Look Back: Week Ending September 27th"
 date: 2020-09-27T19:32:06-04:00
-description: Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+description: A weekly look back. Guildflow 0.11 ships with editable navigation, plus a pair of short feature demo videos.
 series:
   - Journals
 ---

--- a/content/posts/2020/9/look-back-sept-27/index.md
+++ b/content/posts/2020/9/look-back-sept-27/index.md
@@ -6,7 +6,7 @@ series:
   - Journals
 ---
 
-Lots of times it's easy to feel bad about missing deadlines but when you add it all up, it turns out a lot of things happened last week.
+The feature I'd been chasing for two weeks finally landed and shipped. Here's that week, plus everything that happened around it.
 
 ## [Guildflow](/projects/guildflow/)
 

--- a/content/posts/2020/9/migrating-json-file-schema-changes-in-swift/index.md
+++ b/content/posts/2020/9/migrating-json-file-schema-changes-in-swift/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating JSON File Schema Changes in Swift"
 date: 2020-09-01T11:26:25-04:00
-description: A demonstration of how you could save your Swift app's storage as a simple JSON file and then migrate the file schema changes over time. This is particularly useful when you have users generating data and documents in beta builds while the app internals are changing a lot.
+description: How to store a Swift app's data in a JSON file and migrate the schema over time, handy when beta users are generating documents.
 images:
   - posts/2020/9/migrating-json-file-schema-changes-in-swift/thumb.jpeg
 tags:

--- a/content/posts/2020/9/new-member-onboarding/index.md
+++ b/content/posts/2020/9/new-member-onboarding/index.md
@@ -6,7 +6,7 @@ tags:
   - meetups
 ---
 
-> This blog post was orientally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
+> This blog post was originally posted to the Guildflow product blog, which will soon [be shutdown](/posts/2021/10/guildflow-shutdown/).
 
 Even in the before times, being a new person at a meetup event was potentially an extremely overwhelming experience. Now that most group events and socializing are happening online it is even more important to make sure you as a group organizer have a plan for how to onboard new members and make them feel welcome.
 

--- a/content/posts/2021/1/typespecs-and-dialyzer/index.md
+++ b/content/posts/2021/1/typespecs-and-dialyzer/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Understanding the Tradeoffs with Elixir Typespecs and Dialyzer"
 date: 2021-01-20T08:51:42-05:00
-description: Sadly when it comes to dialyzer errors that first error need not be what actually needs to get fixed. Many times you need to fix issues from the middle of the list first and knowing what to fix from that list is a learned art with its own dedicated learning curve.
+description: Dialyzer's first error is often not the one to fix. The tradeoffs of Elixir typespecs, and how to read that error list.
 tags:
   - elixir
 ---

--- a/content/posts/2021/10/guildflow-shutdown/index.md
+++ b/content/posts/2021/10/guildflow-shutdown/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Shutting Down my Side Project Guildflow"
 date: 2021-11-08T12:00:00-04:00
-description: I am shutting down Guildflow because after living in the meetup headspace for two years, I have a hard time seeing a pathway to some level of financial stability which could adequately compensate me for my time.
+description: I am shutting down Guildflow. After two years in the meetup headspace I cannot see a path to paying myself for the time.
 tags:
   - side-projects
 ---

--- a/content/posts/2021/10/phoenix-1.6-upgrade-notes/index.md
+++ b/content/posts/2021/10/phoenix-1.6-upgrade-notes/index.md
@@ -2,7 +2,7 @@
 title: "Personal Phoenix 1.6 Upgrade Notes"
 slug: "phoenix-1.6-upgrade-notes"
 date: 2021-10-18T12:00:00-04:00
-description: Over the past few days I've been upgrading my projects to Phoenix 1.6 and like any project that comes out of a template-based generator, migrating a Phoenix project to a new version can be a little scary and error prone, particularly for people new to Elixir and Phoenix. Today I'll share some personal notes and tips to help make the process a little smoother.
+description: Migrating a Phoenix project to a new version can be scary and error prone. Personal notes and tips from upgrading mine to 1.6.
 pain: confusion and scared about editing generated templates
 fix: some tips for success
 next action: update your project

--- a/content/posts/2021/11/book-thoughts-company-of-one/index.md
+++ b/content/posts/2021/11/book-thoughts-company-of-one/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Book Thoughts: Company of One"
 date: 2021-11-28T14:35:05-05:00
-description: I think this can be a helpful book for those like myself who are contemplating work opportunities, projects, or a new company. However, the valuable topics brought up are much more about growth than the title 'Company of One' really suggests.
+description: Useful reading if you are weighing a new project or company, though it has more to say about growth than the title suggests.
 images:
   - posts/2021/11/book-thoughts-company-of-one/book-cover.jpg
 tags:

--- a/content/posts/2021/2/prioritizing-feedback/index.md
+++ b/content/posts/2021/2/prioritizing-feedback/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Prioritizing Customer Feedback"
 date: 2021-02-20T13:22:33-05:00
-description: It is important to be mindful of how you are spending your time. It can be very easy to fall into a cycle of reacting to things, feeling busy but not actually moving the needle of your business in the way you need to be.
+description: It is easy to react to every piece of customer feedback, feel busy, and move nothing. How I decide what actually gets built.
 tags:
   - side-projects
 ---

--- a/content/posts/2021/2/securing-webhook-payload-delivery/index.md
+++ b/content/posts/2021/2/securing-webhook-payload-delivery/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Securing Webhook Payload Delivery in Phoenix"
 date: 2021-02-22T14:00:00-05:00
-description: Webhook might sound like some scary, exotic term but at the end of the day webhooks are nothing more that a web server endpoint configured to receive HTTP POST requests in some agreed upon format. The concern however is, without any additional security, anyone could discover the endpoint and start sending their own malicious payloads to your web application.
+description: A webhook endpoint is just a POST route, and anyone who finds it can send you a payload. How I secure delivery in Phoenix.
 tags:
   - elixir
 ---

--- a/content/posts/2021/3/retro-taxi-project-kickoff/index.md
+++ b/content/posts/2021/3/retro-taxi-project-kickoff/index.md
@@ -1,6 +1,7 @@
 ---
 title: "RetroTaxi Project Kickoff"
 date: 2021-03-14T16:55:21-04:00
+description: Kicking off RetroTaxi, an open source Phoenix LiveView retrospective board I am building as a teaching example, starting from its pitch document.
 slug: retro-taxi-project-kickoff
 tags:
   - elixir

--- a/content/posts/2021/5/string-vs-atom-maps/index.md
+++ b/content/posts/2021/5/string-vs-atom-maps/index.md
@@ -2,6 +2,7 @@
 title: "Understanding when to use String-based Maps vs Atom-based Maps"
 slug: string-vs-atom-maps
 date: 2021-05-31T10:56:17-04:00
+description: Elixir maps take string keys or atom keys, and the mix trips up beginners. Here is how I decide which to use, and where the boundary belongs.
 pain: "confusion about lack of consistency regarding string-based maps vs atom-based maps"
 fix: "reaffirming the syntax rules and a guideline to follow in your own code"
 tags:

--- a/content/posts/2021/5/values/index.md
+++ b/content/posts/2021/5/values/index.md
@@ -1,7 +1,7 @@
 ---
 title: "The Values That Define Us"
 date: 2021-05-17T10:30:00-04:00
-description: Having well-thought-out and excessively reenforced values are an extremely helpful tool to help shape and align the inevitable hard discussions and decisions that need to be made within an organization.
+description: Well-considered values shape the hard discussions and decisions an organization has to make. Here are the ones I hold.
 tags:
   - career
 ---

--- a/content/posts/2021/6/programming-terminology/index.md
+++ b/content/posts/2021/6/programming-terminology/index.md
@@ -2,6 +2,7 @@
 title: "Improve the Clarity of Your Elixir Code Through Expressive and Consistent Language"
 slug: "programming-terminology"
 date: 2021-06-06T12:00:00-04:00
+description: A list of terms I try to use consistently in my Elixir code, and a nudge to build a shared vocabulary with your team.
 tags:
   - elixir
   - software-craft

--- a/content/posts/2021/6/summer-plans/index.md
+++ b/content/posts/2021/6/summer-plans/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Consulting Retrospective and Summer Learning Plans"
 date: 2021-06-25T16:51:24-04:00
-description: After dedicating a full time effort towards an Elixir/Phoenix consulting project since October, I'm taking some time off and looking forward to a nice mix of vacation and personal projects.
+description: After a full time Elixir and Phoenix consulting run since October, I am taking time off for vacation and personal projects.
 tags:
   - consulting
 ---

--- a/content/posts/2021/7/elixir-job-resources/index.md
+++ b/content/posts/2021/7/elixir-job-resources/index.md
@@ -2,6 +2,7 @@
 title: "Resources and Suggestions to Find Elixir-based Employment"
 slug: "elixir-job-resources"
 date: 2021-07-16T16:12:03-04:00
+description: Job boards, Slack rooms, newsletters, and other places to look when you want full time or contract work writing Elixir.
 tags:
   - elixir
   - career

--- a/content/posts/2021/8/people-first/index.md
+++ b/content/posts/2021/8/people-first/index.md
@@ -1,7 +1,7 @@
 ---
 title: "The Purpose of a Business is People"
 date: 2021-08-05T14:04:56-04:00
-description: The primary goal of the ideal business should be to provide a long-term, welcoming and supportive environment for its workers. Worker satisfaction comes from meaningful, rewarding and sustainable work.
+description: The purpose of a business should be to give its workers a long-term, welcoming environment and meaningful, sustainable work.
 images:
   - posts/2021/8/people-first/purpose-of-business.png
 tags:

--- a/content/posts/2021/8/rust/index.md
+++ b/content/posts/2021/8/rust/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Learning Rust via Game Development"
 date: 2021-08-12T11:59:26-04:00
-description: A short show and tell for how I am learning Rust through game development.
+description: A short show and tell on how I am learning Rust by working through game development exercises.
 tags:
   - rust
   - gaming

--- a/content/posts/2021/9/ecto-schemaless-changesets/index.md
+++ b/content/posts/2021/9/ecto-schemaless-changesets/index.md
@@ -2,7 +2,7 @@
 title: "Using Schemaless Changesets to Separate Concerns Between the Web Context and the Business Context"
 slug: "ecto-schemaless-changesets"
 date: 2021-09-07T08:00:00-04:00
-description: With schemaless changesets you have the power to hand craft validations for specific web form presentations and define firm boundaries of responsibilities between your web presentation layer and the business-specific contexts of your app.
+description: Schemaless changesets let you hand craft validations for a web form and keep a firm boundary between web and business contexts.
 pain: my schemas have grown large and scary. I find myself making web-form specific changesets in the main app contexts which feels wrong.
 fix: two options can help, break down domain into smaller entities, break the changeset dependencies using schemaless changesets
 next action: see how I do this in RetroTaxi, also see these docs and blog posts

--- a/content/posts/2021/9/parameters-vs-attributes/index.md
+++ b/content/posts/2021/9/parameters-vs-attributes/index.md
@@ -2,7 +2,7 @@
 title: "Elixir Terminology: Parameters vs Attributes"
 slug: "parameters-vs-attributes"
 date: 2021-09-13T10:00:00-04:00
-description: When we say "parameters" we are usually talking about data coming into the system from external actors; When we say "attributes" we are usually talking about internal Elixir structures.
+description: Parameters are data arriving from outside the system. Attributes are the internal Elixir structures. Why I keep them straight.
 pain: confusion about seeing the two terms for roughly the same behavior
 fix: an explanation of the differences
 next action: next

--- a/content/posts/2021/9/retro-taxi-sept-2021-update/index.md
+++ b/content/posts/2021/9/retro-taxi-sept-2021-update/index.md
@@ -2,6 +2,7 @@
 title: "Retro Taxi: September 2021 Update"
 slug: "retro-taxi-project-sept-2021-update"
 date: 2021-09-02T09:00:41-04:00
+description: A progress update on RetroTaxi, my Phoenix LiveView retrospective board, with a video walkthrough of what works so far.
 tags:
   - elixir
   - side-projects

--- a/content/posts/2021/9/rust-game-update/index.md
+++ b/content/posts/2021/9/rust-game-update/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Learning Rust via Game Development: Starting Dungeon Crawler"
 date: 2021-09-02T09:45:54-04:00
-description: A short show and tell for how I am learning Rust through game development.
+description: A second Hands-on Rust update, this time building a graphic turn-based dungeon crawler. Video demo included.
 tags:
   - rust
   - gaming

--- a/content/posts/2022/10/advice-for-new-consultants/index.md
+++ b/content/posts/2022/10/advice-for-new-consultants/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Advice for New Consultants"
 date: 2022-10-11T10:34:09-04:00
-description: Build in public as much as possible, blog what you learn to teach others and when you have time, don't be afraid to approach the people/projects you care about and ask, "how can I help?"
+description: Build in public, blog what you learn, and do not be afraid to ask the people and projects you care about how you can help.
 tags:
   - consulting
 ---

--- a/content/posts/2022/10/elixir-book-club-testing-book/index.md
+++ b/content/posts/2022/10/elixir-book-club-testing-book/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Elixir Book Club: Testing Elixir, Starts November 13th"
 date: 2022-10-30T11:48:17-04:00
-description: I read this back in April of 2021 and thought well of it. It's a good overview of the various testing tools available and how to apply them to Elixir scenarios and patterns (OTP, Ecto, Phoenix).
+description: Elixir Book Club is reading Testing Elixir starting November 13th, a solid tour of testing tools across OTP, Ecto, and Phoenix.
 images:
   - posts/2022/10/elixir-book-club-testing-book/testing-elixir.jpg
 tags:

--- a/content/posts/2022/11/4-journal-estimate-wins/index.md
+++ b/content/posts/2022/11/4-journal-estimate-wins/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Recent Estimating Work Notes"
 date: 2022-11-04T13:12:04-04:00
-description: The goal of this estimate is to, in a time-boxed format, create a framework for more meaningful discussions to happen. These numbers should not be looked at as facts but shape those first steps of discovery.
+description: An estimate is not a set of facts, it is a time-boxed framework for a better discussion. Notes from recent estimating work.
 images:
   - posts/2022/11/4-journal-estimate-wins/deadlines.jpg
 tags:

--- a/content/posts/2022/11/my-standup-format/index.md
+++ b/content/posts/2022/11/my-standup-format/index.md
@@ -1,7 +1,7 @@
 ---
 title: "My Standup Format"
 date: 2022-11-09T15:00:32-05:00
-description: There is an async standup format I've been using for over a year now, and since it seems to be sticking, I figured I'd take a moment to share it and explain why I like it.
+description: The async standup format I have used for over a year now, and why it has stuck when other formats did not.
 images:
   - posts/2022/11/my-standup-format/we-are-fine.jpg
 tags:

--- a/content/posts/2022/6/extended-vacation/index.md
+++ b/content/posts/2022/6/extended-vacation/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Extended Vacation (Again)"
 date: 2022-06-01T16:51:29-04:00
-description: Repeating my choice from last year, I have decided to take an extended vacation from consulting this summer to catch up on some learning plans and otherwise invest in personal projects.
+description: Repeating last summer's choice, I am taking an extended vacation from consulting to catch up on learning and side projects.
 series:
   - Journals
 ---

--- a/content/posts/2022/8/elixir-conf-plans/index.md
+++ b/content/posts/2022/8/elixir-conf-plans/index.md
@@ -1,7 +1,7 @@
 ---
 title: "ElixirConf Talks of Interest"
 date: 2022-08-29T16:38:56-04:00
-description: I'm attending ElixirConf this week, and in preparation, I looked over the session schedule to see what talks are of interest to me. I figured I'd share my notes in case anyone is curious about what's on my mind.
+description: I went through the ElixirConf schedule to pick out the talks I want to catch. Sharing my notes in case they are useful.
 tags:
   - conferences
   - elixir

--- a/content/posts/2022/8/exercism-elixir-cohort/index.md
+++ b/content/posts/2022/8/exercism-elixir-cohort/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Exercism Elixir Cohort, New Video Series"
 date: 2022-08-02T19:39:16-04:00
-description: Exercism, the popular platform that teaches programming via structured coding exercises, is going to be hosting a free August cohort for their Elixir track. They brand the endeavour an "Exhort".
+description: Exercism is running a free August cohort for its Elixir track, and I am making a video series to follow along with it.
 tags:
   - elixir
 ---

--- a/content/posts/2023/11/new-job/index.md
+++ b/content/posts/2023/11/new-job/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Announcing my New Full-Time Job"
 date: 2023-11-27T18:05:27-05:00
-description: "I have some big news: Starting December 4th, I'll be working full-time as a Senior Elixir Developer for Allovue, where they build web-based accounting software for school districts."
+description: Starting December 4th I am a Senior Elixir Developer at Allovue, building web-based accounting software for school districts.
 tags:
   - career
   - elixir

--- a/content/posts/2023/2/elixir-get-noun-return-type/index.md
+++ b/content/posts/2023/2/elixir-get-noun-return-type/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Elixir Context Accessor Function: Which Return Type Do You Prefer?"
 date: 2023-02-12T13:55:42-05:00
-description: something tweet like
+description: Should a context accessor return `{:ok, noun}` or a bare `noun` or `nil`? Why I am moving toward fetch functions and tuples.
 tags:
   - elixir
   - software-craft

--- a/content/posts/2023/7/circle-credit-card-fraud/index.md
+++ b/content/posts/2023/7/circle-credit-card-fraud/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Circle Sign-Up Forms and Credit Card Fraud"
 date: 2023-07-04T13:00:00-04:00
-description: A short recap of issues I ran into where people were using my Circle community sign-up form to validate stolen credit cards and Circle's lack of proper response.
+description: People used my Circle community sign-up form to validate stolen credit cards, and Circle never responded properly.
 tags:
   - side-projects
 ---

--- a/content/posts/2024/12/new-gaming-pc/index.md
+++ b/content/posts/2024/12/new-gaming-pc/index.md
@@ -1,7 +1,7 @@
 ---
 title: "New Gaming PC"
 date: 2024-12-29T09:22:54-05:00
-description: In the closing days of summer this past year, I started to get an itch about building a new gaming PC. In this post, I'll share what I built and some notes on its assembly.
+description: I got an itch to build a new gaming PC at the end of summer. What I picked, and some notes from the assembly.
 images:
   - posts//2024/12/new-gaming-pc/colors.jpeg
 tags:

--- a/content/posts/2024/4/impactful-books/index.md
+++ b/content/posts/2024/4/impactful-books/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Impactful Books"
 date: 2024-04-14T14:39:36-04:00
-description: A local developer Slack had an icebreaker post asking for programming books that impacted your career. I figured I'd share mine in a more long-lived format. Some are more timeless than others.
+description: A Slack icebreaker asked which programming books shaped your career. Here are mine, in a more long-lived format.
 tags:
   - books
   - reviews

--- a/content/posts/2024/9/elixir-code-aesthetic/index.md
+++ b/content/posts/2024/9/elixir-code-aesthetic/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Personal Elixir Code Aesthetics"
 date: 2024-09-29T20:25:46-04:00
-description: With my side project Flick hitting an MVP milestone and inspired by some conversations during Elixir Book Club, I thought I’d take a moment to document some code aesthetic choices I made in this project.
+description: Documenting the code aesthetic choices I made in Flick, my side project, as it reached its MVP milestone.
 tags:
   - elixir
   - software-craft

--- a/content/posts/2025/1/presenting-datetime-in-user-time-zone-phoenix-live-view/index.md
+++ b/content/posts/2025/1/presenting-datetime-in-user-time-zone-phoenix-live-view/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Phoenix LiveView: Presenting DateTime in User's Time Zone"
 date: 2025-01-22T19:47:37-05:00
-description: This past weekend, I added a feature to Flick (RankedVote.app) where we now present domain-specific `DateTime` values, like `published_at` and `closed_at`, on the live view page using the user's time zone. I thought I'd capture some notes on how this was accomplished, some known limitations, ideas to solve those in your own work, and a set of resource links to learn more.
+description: Notes on rendering `DateTime` values in the user's time zone on a Phoenix LiveView page, including the limitations I ran into.
 images:
   - posts/2025/1/presenting-datetime-in-user-time-zone-phoenix-live-view/days-since-last-timezone-issue.png
 tags:

--- a/content/posts/2025/2/what-is-local-first-software/index.md
+++ b/content/posts/2025/2/what-is-local-first-software/index.md
@@ -1,7 +1,7 @@
 ---
 title: "What is Local-first Software?"
 date: 2025-02-03T09:11:28-05:00
-description: We believe that data ownership and real-time collaboration are not at odds with each other. It is possible to create software that has all the advantages of cloud apps, while also allowing you to retain full ownership of the data. We call this type of software local-first software.
+description: A look at local-first software, the idea that you can have the collaboration of cloud apps while still fully owning your data.
 images:
   - posts/2025/2/what-is-local-first-software/offline-mode.jpg
 tags:

--- a/content/posts/2025/5/ranked-vote-flick-demo/index.md
+++ b/content/posts/2025/5/ranked-vote-flick-demo/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Ranked Vote Flick Demo"
 date: 2025-05-01T19:58:04-04:00
-description: something tweet like
+description: A short demo video of RankedVote.app (Flick), the Elixir and Phoenix LiveView app I built to help the Elixir Book Club pick books.
 tags:
   - side-projects
   - elixir

--- a/content/posts/2025/6/becoming-an-accessibility-ally/index.md
+++ b/content/posts/2025/6/becoming-an-accessibility-ally/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Becoming an Accessibility Ally: My Early Journey and Resources"
 date: 2025-06-12T10:00:00-04:00
-description: In today's post, I'll share some things I learned from the Website Accessibility course and a few tools and resources you can look into if you are interested in leveling up as well.
+description: What I learned from a Website Accessibility course, plus the tools and resources worth a look if you want to level up too.
 images:
   - posts/2025/6/becoming-an-accessibility-ally/axe-dev-tools-firefox-extension.webp
 pain: web developer who might be less experienced on the frontend wants to be an accessibility ally but is not sure where to start

--- a/content/posts/2026/6/fresh-eyes-on-a-cucumbered-team/index.md
+++ b/content/posts/2026/6/fresh-eyes-on-a-cucumbered-team/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Fresh Eyes on a Cucumbered Team"
 date: 2026-06-30T10:43:44-04:00
-description: "There's a term for what happens when you've been on a team so long you stop noticing its quirks: you've been cucumbered. Here's what fresh eyes can (and can't responsibly) do about it."
+description: There is a term for being on a team so long you stop noticing its quirks. What fresh eyes can, and cannot responsibly, do about it.
 pain: teams (and the people on them) stop noticing their own quirks and workarounds the longer they're embedded in a project; this isn't a character flaw, it's structural
 fix: explain the "cucumbered" metaphor and what fresh eyes can (and can't) responsibly do about it
 tags:

--- a/content/posts/2026/7/a-place-for-everything/index.md
+++ b/content/posts/2026/7/a-place-for-everything/index.md
@@ -1,7 +1,7 @@
 ---
 title: "A Place for Everything: How I Track Work"
 date: 2026-07-03T13:56:35-04:00
-description: "A window into how I track work: issue statuses, types, and pull request conventions, with sample PR templates you can copy. Take a look around and keep what's useful."
+description: How I track work, from issue statuses and types to pull request conventions, with sample PR templates you can copy.
 pain: curious developers like to read how others work and get inspired
 fix: a window into my own opinionated system -- issue tracking, a status flow, issue types, and PR conventions -- to discover and cherry-pick from
 tags:

--- a/content/posts/2026/7/decision-records-and-playbooks/index.md
+++ b/content/posts/2026/7/decision-records-and-playbooks/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Decision Records, Playbooks, and Other Acts of Kindness"
 date: 2026-07-02T11:19:12-04:00
-description: You've opened a project you didn't write, hit a wall, and found no one left to ask. The code is there but the why is gone. Here are the small habits that spare the next developer that moment.
+description: You open a project you did not write, hit a wall, and find no one left to ask. The habits that spare the next developer that moment.
 pain: the practices that keep a codebase healthy are easy to skip under pressure, and the cost lands on whoever inherits the project later
 fix: a scannable rundown of the non-code practices that make life better for the next developer -- and why each one is worth the effort
 tags:

--- a/content/posts/2026/7/guarding-against-ai-drift/index.md
+++ b/content/posts/2026/7/guarding-against-ai-drift/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Guarding Against AI Drift: My Automated Elixir Quality Checks"
 date: 2026-07-22T11:14:06-04:00
-description: As I experiment more with AI code generation, I've hardened LocalCents with more automated Elixir quality checks than I've ever run. Here's the whole guardrail setup, each linked to how it's wired in the real repo.
+description: I have hardened LocalCents with more automated Elixir quality checks than I have ever run. The whole guardrail setup, wired in a real repo.
 pain: as I generate more code with AI, I'm shipping more than ever and worried it will quietly drift away from my own standard of good code
 fix: walk through the automated Elixir guardrails I run on LocalCents, each linked to its real implementation, so a peer can steal the ones they're missing
 bob-promise: after reading this you'll have a concrete, copyable checklist of Elixir CI guardrails to keep AI-generated code from drifting toward the median

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Blog
+description: The full archive of my writing since 2012, covering Elixir and Phoenix, iOS and macOS, running a small software business, and daily practice.
 cascade:
   sectionHighlight: Blog
 ---

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Projects
+description: A running list of what I have built, including personal side projects, past products, and client work, with write-ups on how each one went.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/agency.md
+++ b/content/projects/agency.md
@@ -1,5 +1,6 @@
 ---
 title: Agency Projects
+description: A generic look at the NDA'd iOS and Android work I did as a full-time employee at a pair of large agencies.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/dex.md
+++ b/content/projects/dex.md
@@ -1,5 +1,6 @@
 ---
 title: Dex
+description: Dex was my first real iOS app, a Pokemon reference tool that hit about a million downloads before Nintendo legal asked for its removal.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/elixir_club.md
+++ b/content/projects/elixir_club.md
@@ -1,5 +1,6 @@
 ---
 title: Elixir Club
+description: ElixirClub was a community site meant to help Elixir developers finish their side projects. I ran it for about six months before shutting it down.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/elixir_focus.md
+++ b/content/projects/elixir_focus.md
@@ -1,5 +1,6 @@
 ---
 title: Elixir Focus / Phoenix by Example
+description: Phoenix by Example, later renamed Elixir Focus, was my run at paid educational content for Elixir developers, and why I stepped away from it.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/franklin.md
+++ b/content/projects/franklin.md
@@ -1,5 +1,6 @@
 ---
 title: Franklin
+description: Franklin was an intentionally over-engineered blog app in Elixir, Phoenix, and LiveView, built to learn event sourcing and CQRS with Commanded.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/geo.md
+++ b/content/projects/geo.md
@@ -1,5 +1,6 @@
 ---
 title: GEO
+description: GEO was a 2010 team project, an iOS game that turned walking your neighborhood into fighting monsters and leveling up. Pokemon Go, a few years early.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/guildflow.md
+++ b/content/projects/guildflow.md
@@ -1,5 +1,6 @@
 ---
 title: Guildflow
+description: Guildflow gave meetup organizers a modern group website that respected member data and privacy. I ran it for two years, then shut it down.
 sectionHighlight: Projects
 layout: onepage
 aliases: /projects/club-house-hosting/

--- a/content/projects/megamaneffect.md
+++ b/content/projects/megamaneffect.md
@@ -1,5 +1,6 @@
 ---
 title: MegaManEffect
+description: MegaManEffect was my first real Mac app, playing a MegaMan 2 animation as you launched apps. Built at MacHack, later featured on Attack of the Show.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/mikezornek-site.md
+++ b/content/projects/mikezornek-site.md
@@ -1,5 +1,6 @@
 ---
 title: Mike Zornek (Personal Website)
+description: Background on this website, a Hugo static site with a handcrafted theme, open source on GitHub and published automatically on every push.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/owldeck.md
+++ b/content/projects/owldeck.md
@@ -1,5 +1,6 @@
 ---
 title: OwlDeck
+description: OwlDeck was a macOS presentation tool for programmers who live in Markdown. I shelved it after fighting the low-level macOS text system.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/philly-cocoaheads/_index.md
+++ b/content/projects/philly-cocoaheads/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Philly CocoaHeads Website
+description: How I rebuilt the Philly CocoaHeads website, moving off WordPress and onto Hugo with a custom theme and automated publishing.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/profittrain.md
+++ b/content/projects/profittrain.md
@@ -1,5 +1,6 @@
 ---
 title: ProfitTrain
+description: ProfitTrain, formerly Billable, was my time tracking and invoicing app for Mac. A small, successful product I eventually sold to RazorAnt.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/roar/_index.md
+++ b/content/projects/roar/_index.md
@@ -1,5 +1,6 @@
 ---
 title: ROAR For Good
+description: ROAR For Good's AlwaysOn is a panic-button safety platform for hotel staff. I helped build its backend and admin tools in Elixir and Phoenix.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/shindig.md
+++ b/content/projects/shindig.md
@@ -1,5 +1,6 @@
 ---
 title: Shindig
+description: Shindig was a startup where I served as co-owner and CTO, generating iOS, Android, and web apps for conference attendees off a Rails backend.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/trafficcast.md
+++ b/content/projects/trafficcast.md
@@ -1,5 +1,6 @@
 ---
 title: TrafficCast
+description: Two years of iOS consulting for TrafficCast, including a rebuild of their network stack that I later turned into a conference talk.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/projects/twizshow.md
+++ b/content/projects/twizshow.md
@@ -1,5 +1,6 @@
 ---
 title: TwizShow
+description: TwizShow was an iOS game that built a game show out of your Twitter data. Fun to make, no traction, pulled when Twitter changed its API rules.
 sectionHighlight: Projects
 layout: onepage
 ---

--- a/content/random.md
+++ b/content/random.md
@@ -1,5 +1,6 @@
 ---
 title: Random Post
+description: A random post pulled from the archive, re-rolled every time you land here.
 layout: random
 build:
   list: never

--- a/content/search/_index.md
+++ b/content/search/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Search"
+description: Search every post on this site by title, tag, and content.
 sitemap:
   priority: 0.1
 layout: "search"

--- a/content/series/31-days-31-products/_index.md
+++ b/content/series/31-days-31-products/_index.md
@@ -1,0 +1,4 @@
+---
+title: "31 Days 31 Products"
+description: A month of short daily write-ups on the software and hardware I use and enjoy, one product per day.
+---

--- a/content/series/_index.md
+++ b/content/series/_index.md
@@ -1,0 +1,4 @@
+---
+title: Series
+description: Multi-part collections of posts meant to be read together, including my personal journals, 31 Days 31 Products, and the Exercism Elixir track.
+---

--- a/content/series/exercism-elixir-track/_index.md
+++ b/content/series/exercism-elixir-track/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Exercism Elixir Track"
+description: A video series working through the Exercism Elixir track, one exercise at a time.
+---

--- a/content/series/journals/_index.md
+++ b/content/series/journals/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Journals"
+description: Personal journal entries, including monthly reviews, retrospectives, and updates on what has been going on.
+---

--- a/content/tags/_index.md
+++ b/content/tags/_index.md
@@ -1,0 +1,4 @@
+---
+title: Tags
+description: Browse the blog archive by topic, from Elixir and iOS to AI, consulting, career, and the everyday practices of software craft.
+---

--- a/content/tags/ai/_index.md
+++ b/content/tags/ai/_index.md
@@ -1,0 +1,4 @@
+---
+title: "ai"
+description: Posts on coding with AI, what three years of it changed for me, the ethics of it, and the guardrails I put around the output.
+---

--- a/content/tags/apple/_index.md
+++ b/content/tags/apple/_index.md
@@ -1,0 +1,4 @@
+---
+title: "apple"
+description: Posts about Apple, the Mac and iOS platforms, App Store policy, repairability, and the company's choices along the way.
+---

--- a/content/tags/books/_index.md
+++ b/content/tags/books/_index.md
@@ -1,0 +1,4 @@
+---
+title: "books"
+description: Book notes and reviews on programming, design, and business, plus what I have learned running a book club.
+---

--- a/content/tags/career/_index.md
+++ b/content/tags/career/_index.md
@@ -1,0 +1,4 @@
+---
+title: "career"
+description: Posts on the working life of a developer, from self-employment and job hunts to retrospectives and what a business is for.
+---

--- a/content/tags/conferences/_index.md
+++ b/content/tags/conferences/_index.md
@@ -1,0 +1,4 @@
+---
+title: "conferences"
+description: Notes, recaps, and talk write-ups from the conferences and meetups I have attended and spoken at over the years.
+---

--- a/content/tags/consulting/_index.md
+++ b/content/tags/consulting/_index.md
@@ -1,0 +1,4 @@
+---
+title: "consulting"
+description: Posts on consulting work, from finding clients and setting expectations to estimating, tracking work, and getting paid.
+---

--- a/content/tags/devops/_index.md
+++ b/content/tags/devops/_index.md
@@ -1,0 +1,4 @@
+---
+title: "devops"
+description: Posts on build and deploy plumbing, including continuous integration, provisioning, hosting, and the scripts between them.
+---

--- a/content/tags/elixir/_index.md
+++ b/content/tags/elixir/_index.md
@@ -1,0 +1,4 @@
+---
+title: "elixir"
+description: Posts on Elixir and Phoenix, from LiveView and Ecto to typespecs, testing, code aesthetics, and upgrade notes.
+---

--- a/content/tags/gaming/_index.md
+++ b/content/tags/gaming/_index.md
@@ -1,0 +1,4 @@
+---
+title: "gaming"
+description: Gaming updates and write-ups, from World of Warcraft and Hearthstone to learning Rust by building a dungeon crawler.
+---

--- a/content/tags/hardware/_index.md
+++ b/content/tags/hardware/_index.md
@@ -1,0 +1,4 @@
+---
+title: "hardware"
+description: Posts about the machines I work and play on, from Macs and monitors to a Framework laptop and a home-built gaming PC.
+---

--- a/content/tags/ios/_index.md
+++ b/content/tags/ios/_index.md
@@ -1,0 +1,4 @@
+---
+title: "ios"
+description: Posts on iOS and Swift development, covering architecture, testing, tooling, and what it really costs to ship an app.
+---

--- a/content/tags/meetups/_index.md
+++ b/content/tags/meetups/_index.md
@@ -1,0 +1,4 @@
+---
+title: "meetups"
+description: Posts on starting, running, and sustaining meetup groups, most of it learned the hard way at Philly CocoaHeads.
+---

--- a/content/tags/practices/_index.md
+++ b/content/tags/practices/_index.md
@@ -1,0 +1,4 @@
+---
+title: "practices"
+description: Posts on the daily practice of software work, including code review, documentation, decision records, and tracking work.
+---

--- a/content/tags/privacy/_index.md
+++ b/content/tags/privacy/_index.md
@@ -1,0 +1,4 @@
+---
+title: "privacy"
+description: Posts on privacy and the open web, from self-hosting fonts to local-first software and where the browser vendors stand.
+---

--- a/content/tags/reviews/_index.md
+++ b/content/tags/reviews/_index.md
@@ -1,0 +1,4 @@
+---
+title: "reviews"
+description: Reviews of the software, hardware, books, movies, and music I actually spend my time with.
+---

--- a/content/tags/rust/_index.md
+++ b/content/tags/rust/_index.md
@@ -1,0 +1,4 @@
+---
+title: "rust"
+description: Posts from learning Rust the fun way, by building a dungeon crawler game.
+---

--- a/content/tags/side-projects/_index.md
+++ b/content/tags/side-projects/_index.md
@@ -1,0 +1,4 @@
+---
+title: "side-projects"
+description: Posts about my side projects, the ones that shipped, the ones I shut down, and what each one taught me.
+---

--- a/content/tags/software-craft/_index.md
+++ b/content/tags/software-craft/_index.md
@@ -1,0 +1,4 @@
+---
+title: "software-craft"
+description: Posts on writing software well, from what good code is to the habits that keep a codebase healthy for the next person.
+---

--- a/content/tags/web-development/_index.md
+++ b/content/tags/web-development/_index.md
@@ -1,0 +1,4 @@
+---
+title: "web-development"
+description: Posts on web development, from Hugo and static sites to accessibility, web fonts, and front end experiments.
+---

--- a/content/talks.md
+++ b/content/talks.md
@@ -1,5 +1,6 @@
 ---
 title: Talks
+description: A record of the conferences and meetups I have spoken at and attended over the years, with links to the talks I gave.
 sectionHighlight: Talks
 layout: onepage
 ---

--- a/decisions/page-metadata.md
+++ b/decisions/page-metadata.md
@@ -107,10 +107,11 @@ own. Doing it in the template hides bad authoring instead of surfacing it, and
 archetype already asks for "tweet-length"; descriptions that overshoot should
 be rewritten by hand.
 
-#155 did exactly that for the 42 that had overshot. The working target is
-**160 characters as a ceiling, roughly 100–140 as the comfortable band**: long
-enough to say something specific, short enough that Google and the social cards
-both show the whole sentence.
+#155 did exactly that for the 42 that had overshot. The working target is **160
+characters as a hard ceiling**, and roughly 100–140 where the page has that
+much worth saying: long enough to be specific, short enough that Google and the
+social cards both show the whole sentence. Shorter is fine when the page is
+simple; only the ceiling is a rule.
 
 ---
 

--- a/decisions/page-metadata.md
+++ b/decisions/page-metadata.md
@@ -18,11 +18,16 @@ and runs past 300 characters. Feeding that to `meta description` trades one bad
 snippet for another: search engines discount a weak description and synthesize
 their own either way, so the fallback buys nothing and risks worse.
 
-Pages with no `description` front matter therefore emit the site description,
-exactly as they did before — currently **251 of 519 rendered pages**, almost
-all of them the pre-2020 post archive plus every page under
-`content/projects/`. The fix for those is to write the description, not to
-generate one; that backfill is issue #155.
+Pages with no `description` front matter therefore emit the site description.
+That was **251 of 519 rendered pages** when this was written, almost all of
+them the pre-2020 post archive plus every page under `content/projects/`. The
+fix was to write the description, not to generate one; issue #155 backfilled
+all of them. Today the only page still on the fallback is `404.html`, which has
+no front matter to write.
+
+That is the state to keep. A new page without a `description` silently rejoins
+the fallback, so the archetype's placeholder is a prompt, not a default to
+ship.
 
 ---
 
@@ -55,8 +60,10 @@ The two tags have different consumers and different failure modes:
   suburbs of Philadelphia" tells a reader nothing about the link. The page's own
   first two sentences, imperfect as they are, tell them something.
 
-Once every page has an authored `description` (#155), the divergence
-disappears on its own, because both chains start at `.Description`.
+Now that every page has an authored `description` (#155), the divergence is
+gone, because both chains start at `.Description` and find it. The tolerance
+above is what keeps a future page without one from being a bug rather than a
+cosmetic mismatch.
 
 The one thing to keep in step is escaping: `head.html` applies
 `plainify | htmlUnescape`, matching the embedded templates. Without the
@@ -99,6 +106,11 @@ own. Doing it in the template hides bad authoring instead of surfacing it, and
 `truncate` cuts wherever it lands rather than where a sentence ends. The
 archetype already asks for "tweet-length"; descriptions that overshoot should
 be rewritten by hand.
+
+#155 did exactly that for the 42 that had overshot. The working target is
+**160 characters as a ceiling, roughly 100–140 as the comfortable band**: long
+enough to say something specific, short enough that Google and the social cards
+both show the whole sentence.
 
 ---
 


### PR DESCRIPTION
Closes #155.

Every page on the site now carries its own `description`. Before this branch, 256 of them fell back to the site-wide line ("Personal website of Mike Zornek..."), which tells a reader nothing about the link they are about to open.

## Backfill

The issue counted 232 archive posts with no description, a clean cutoff at 2021 and earlier, plus the project pages, section indexes, and a few one-offs. All of them are done, one commit per year so the diff is reviewable in slices:

| Group | Pages |
|---|---|
| 2012–2021 posts | 233 |
| `content/projects/*` | 16 |
| Section indexes, contact / follow / talks / random / search / home | 8 |

The issue offered a Plausible-triaged top slice as an option. This does the whole archive instead.

## The over-long ones

The 42 descriptions past 160 characters were rewritten by hand rather than truncated in the template, per the "No truncation in the template" section of `decisions/page-metadata.md`. The 374-character one on the LiveView time zone post is now 122. Longest anywhere on the site is 149.

## Beyond the issue's list

To actually close the gap site-wide, this also adds:

- `content/tags/_index.md` and `content/series/_index.md` — named in the issue, but they did not exist as files.
- A term `_index.md` for all 19 tags and 3 series. These were the last pages on the fallback. Each restates its title verbatim, because Hugo drops the auto-derived term title once a term `_index.md` exists.

Every rendered page except `404.html` now emits its own description, and `meta description` and `og:description` agree everywhere. That is the divergence `decisions/page-metadata.md` predicted would resolve on its own once every page had an authored description.

## Also fixed along the way

Two posts were shipping the archetype's `something tweet like` placeholder, and fifteen posts shared a copied description with a sibling (nine weekly `look-back-*` posts, two December ones, two Rust videos). The backfill targeted pages *missing* the field, so it stepped over both groups. All now say something specific to their own page. Every description on the site is unique.

## Two side effects worth knowing about

- `themes/reborn/layouts/partials/post-card.html` prefers `.Description` over `.Summary`, so these descriptions are now the blurb on every list, tag, and series page, not just in the `<head>`. An improvement, but a wider visible change than the issue implied. That file's `something tweet like` guard is now dead code, left in as a net for future leaks.
- `/tags/` and `/series/` now render `<title>Tags • Mike Zornek</title>` instead of lowercase `tags`, because the new section files set a title. The `<h1>` was already capitalized, so nothing on the page moved.

## Verification

Built both `main` and this branch and diffed the rendered output. Across all 22 term pages the only differences are the description meta tags: no `<h1>` change, no post-list change, no page count change, sitemap and RSS unchanged.

- 0 pages without a description (down from 256)
- 0 descriptions over 160 characters (down from 42)
- 0 duplicate descriptions (down from 17 pages sharing 4 strings)
- 0 em dashes introduced, per `decisions/word-choice.md`
- Hugo builds clean; Prettier clean on everything touched

`decisions/page-metadata.md` is updated to record the finished state and the 160-character ceiling, so the doc no longer describes a gap that is closed.
