### PR TITLE
Fix two broken og:image paths and align CI's Node version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,9 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # Read the version from `.node-version` rather than repeating it here, so
+      # this check runs on the same Node the deploy does. Render reads that file
+      # too, though a `NODE_VERSION` env var in the Render dashboard takes
+      # precedence over it if one is set.
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version-file: ".node-version"
       # Runs the same script Render uses to deploy. Because bin/build.sh sets
       # `errexit`, any Hugo error (bad YAML front matter, broken ref/relref
       # links, template errors, missing image resources) becomes a red check

--- a/content/posts/2023/2/github-action-talk/index.md
+++ b/content/posts/2023/2/github-action-talk/index.md
@@ -3,7 +3,7 @@ title: "Github Action Talk"
 date: 2023-02-28T13:52:26-05:00
 description: I'm going to be doing a talk about GitHub Actions for ElixirClub.
 images:
-  - posts/posts/2023/2/github-action-talk/github-actions.png
+  - posts/2023/2/github-action-talk/github-actions.png
 tags:
   - devops
 ---

--- a/content/posts/2025/4/google-sheets-expense-budgeting/index.md
+++ b/content/posts/2025/4/google-sheets-expense-budgeting/index.md
@@ -3,7 +3,7 @@ title: "Using Google Sheets to Catalog Expenses for Budgeting Considerations"
 date: 2025-04-19T11:07:02-04:00
 description: This is how I catalog my planned expenses when reviewing personal budget scenarios. Google sheet and video demo attached.
 images:
-  - posts/posts/2025/4/google-sheets-expense-budgeting/budget-preview.png
+  - posts/2025/4/google-sheets-expense-budgeting/budget-preview.png
 tags:
   - practices
 ---


### PR DESCRIPTION
Two small, unrelated fixes surfaced while scoping the OG image work in #103. Neither is part of that feature, so they are split out here to ship on their own.

## Fix two `og:image` paths that pointed at nothing

`google-sheets-expense-budgeting` and `github-action-talk` both had a doubled `posts/` in their `images` front matter:

```yaml
images:
  - posts/posts/2025/4/google-sheets-expense-budgeting/budget-preview.png
    ^^^^^^^^^^^^
```

So the site emitted an `og:image` at `/posts/posts/2025/4/.../budget-preview.png` while the file actually publishes to `/posts/2025/4/.../budget-preview.png`. Anyone sharing either post fetched a 404 and got a text-only card, on two posts that are declaring `twitter:card: summary_large_image`.

Verified against a real `hugo` build: both URLs now resolve to files that exist in `public/`.

**Why the build never caught it:** `images` front matter is not a resource lookup. Hugo's `_funcs/get-page-images` falls through to `.Params.images` and runs `absURL` over the raw string, which is pure concatenation, no existence check. There is no failure to detect, so the build stays green and the only symptom lives on someone else's website. #159 tracks adding a guard so this class of bug fails the build.

## Read the CI Node version from `.node-version`

`.github/workflows/build.yaml` independently repeated `node-version: "22"`, which resolves to whatever 22.x is newest, while the tracked `.node-version` pins `22.14.0` for local work and for Render. So the check that exists to prove "if this is green, Render will build" was running on a different Node than Render.

Harmless today, since the build only needs Node for Tailwind and Prettier. Not harmless once #103 adds a native N-API addon whose prebuilt binaries are compiled per Node ABI, and whose failure mode on the Render build image is a hard failure with no compile-from-source fallback.

The workflow now reads the file, so one place drives all three environments. Caveat recorded in a comment: Render's documented precedence puts a `NODE_VERSION` dashboard env var above the file, and the commit that added `.node-version` says one is set, so the dashboard remains the real authority and should be reconciled before anyone bumps the pin. #160 tracks that.
