### PR TITLE
Record the measured card generation time on Render [skip render]

### DIFF
--- a/decisions/og-images.md
+++ b/decisions/og-images.md
@@ -49,7 +49,22 @@ regenerates everything. The generation step therefore times itself and prints
 the duration, so the Render log reports the real number against that budget
 rather than us guessing at it.
 
-If that number turns out to be bad, the documented escape hatch is
+**Measured on the first production deploy (2026-07-29): 9.1 seconds for 444
+cards, 20.4ms each.** Locally the same run takes 7.0s at 15.9ms, so Render's
+two-CPU builder is roughly 30% slower, which is unremarkable. Against a budget
+of 500 pipeline minutes a month, nine seconds a deploy is not a number worth
+optimising: even a hundred deploys in a month spends about fifteen minutes of it
+on cards. The question this entry was written to answer is settled, and the
+answer is that it does not matter.
+
+Two things that deploy also confirmed. `Cleaned │ 0` in Hugo's summary shows
+`--cleanDestinationDir` is a no-op on Render, because every build starts from a
+fresh checkout; it earns its place for local runs only. And the native takumi
+binary resolved on `linux/amd64` without incident, which retires the sharpest
+risk in the research note: there is no Rust toolchain on the build image, so a
+missing prebuilt binary would have failed the deploy outright.
+
+If that number ever does turn bad, the documented escape hatch is
 `$XDG_CACHE_HOME`, which Render persists between builds. Note the research flags
 it as undocumented for static sites specifically, so it is a lead, not a plan.
 


### PR DESCRIPTION
Follow-up to #103 / #163. Docs only, no code.

`decisions/og-images.md` said the generation step times itself "so the Render log reports the real number against that budget rather than us guessing at it." The first production deploy reported it, so this writes the number down and closes the question.

## What the deploy measured

| | cards | total | per card |
| --- | --- | --- | --- |
| Render (2 CPU) | 444 | **9.1s** | 20.4ms |
| Local (M-series) | 444 | 7.0s | 15.9ms |

Render's builder is about 30% slower, which is unremarkable. Against 500 pipeline minutes a month, nine seconds a deploy is not worth optimising: a hundred deploys in a month would spend roughly fifteen minutes of the budget on cards. The entry now says so plainly rather than leaving a "measure this" note open forever.

## Two risks the deploy also retired

**`--cleanDestinationDir` is a no-op on Render.** Hugo reported `Cleaned │ 0`, because every build starts from a fresh checkout. It was flagged as scope creep during review, and this confirms it costs production nothing and earns its place for local runs only, where `public/` accumulates stale drafts.

**The native takumi binary resolved on `linux/amd64`.** This was the sharpest risk in `docs/render-static-site-constraints.md`: Render's build image ships `gcc`, `g++`, and `make` but **no Rust toolchain**, so a missing prebuilt binary would have failed the deploy outright with no compile-from-source fallback. It resolved cleanly.

## Confirmed live

The verifier passed in the real environment, not just locally:

```
[verify-og] 520 pages, 1040 image URLs checked against https://mikezornek.com, 190 redirect/noindex pages skipped
[verify-og] all social images resolve
```

And the cards are being served, at byte-identical sizes to the local build:

```bash
curl -sI https://mikezornek.com/og/v1/index.png | head -1
curl -sI https://mikezornek.com/og/v1/elixir-consulting.png | head -1
```

Both `200`, `image/png`. A cross-check worth noting: Hugo reported 189 aliases, and the verifier skipped 190 pages, which is those 189 redirect stubs plus `/random/`. The two counts agreeing independently is a small sign the skip rules match reality rather than merely passing.
