### PR TITLE
Serve robots.txt and point it at the sitemap

### DIFF
--- a/decisions/README.md
+++ b/decisions/README.md
@@ -5,6 +5,7 @@ don't have to be rediscovered later.
 
 One file per topic. Add a new file when a new kind of decision comes up.
 
+- [ai-crawlers.md](ai-crawlers.md) — who `robots.txt` lets in, and why that includes AI training crawlers
 - [page-metadata.md](page-metadata.md) — meta description, Open Graph, and Twitter card tags
 - [og-images.md](og-images.md) — generating the social card image each page shares with
 - [word-choice.md](word-choice.md) — preferred spellings and word forms

--- a/decisions/ai-crawlers.md
+++ b/decisions/ai-crawlers.md
@@ -1,0 +1,45 @@
+# Let every crawler in, including AI training crawlers
+
+`robots.txt` allows all user agents everywhere. We do not block AI answer
+engines (`OAI-SearchBot`, `PerplexityBot`, `Claude-SearchBot`) and we do not
+block AI training crawlers (`GPTBot`, `ClaudeBot`, `CCBot`, `Google-Extended`,
+`Applebot-Extended`) either.
+
+**Why:** the point of this blog is for people in the Elixir community to know
+who Mike is. A model that has read these posts and can answer "who writes about
+Elixir consulting near Philadelphia" is distributing exactly the thing the blog
+exists to distribute. Blocking training crawlers would trade that away to
+protect writing that is already published for free, in public, with an RSS feed
+that serves full post bodies to anyone who asks.
+
+Two facts that shaped the call:
+
+- **Blocking training does not keep you out of AI answers.** Google's AI
+  Overviews are built from the ordinary Googlebot index; `Google-Extended` only
+  opts out of Gemini model training. So "let the answer engines cite me, keep
+  the trainers out" buys much less protection than it sounds like it does, and
+  it costs presence in the models people ask career questions of.
+- **The old objection was cost, not principle.** Issue #100 ("add thing to
+  reduce ai browsing") was about staying under a Render bandwidth cap, and it
+  was resolved by enabling billing, not by taking a position on crawlers.
+
+**Considered and rejected:**
+
+- _Answers yes, training no_ — the common writer's position, and a coherent one.
+  It is an objection to uncompensated commercial use of scarce or paid work.
+  That is not what this blog is.
+- _Block the bad citizens_ (`Bytespider`, `Amazonbot`, `Diffbot`) on bandwidth
+  grounds — the arithmetic does not justify it. Hobby includes 5 GB/month and
+  overage is $0.15/GB, so an aggressive crawler on a site this size costs
+  dollars, not tens of dollars. And a crawler badly behaved enough to matter is
+  a crawler that ignores `robots.txt`.
+- _Explicit per-bot `Allow:` blocks_ — `User-agent: *` already covers them, so
+  they add nothing but a list that rots as bots are renamed.
+
+**What would change our minds:** a Render bill where crawler traffic is a
+visible line item, or evidence that a specific crawler is republishing posts
+in full rather than citing them.
+
+**Consequence:** `robots.txt` stays short. New crawlers need no action — they
+are allowed by default, which is the intended posture. If we ever do want to
+block one, this file should be updated in the same commit as the `Disallow`.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,5 +1,9 @@
 baseURL: "https://mikezornek.com"
 locale: "en-US"
+# Render themes/reborn/layouts/robots.txt. Off by default in Hugo, and while it
+# was off the site served a 404 at /robots.txt, so no crawler was ever told
+# where the sitemap lives. See decisions/ai-crawlers.md.
+enableRobotsTXT: true
 title: "Mike Zornek"
 description: Personal website of Mike Zornek, a developer and teacher from the suburbs of Philadelphia.
 theme: "reborn"

--- a/themes/reborn/layouts/robots.txt
+++ b/themes/reborn/layouts/robots.txt
@@ -11,11 +11,14 @@
   crawlers. The reasoning, and what we would have to see to change our minds,
   is in decisions/ai-crawlers.md.
 
-  Note what is *not* here: `/random/` and `/search/` carry `noindex` meta tags
-  and are deliberately left crawlable. A `Disallow` would prevent those pages
-  from being fetched, so the `noindex` would never be read, and search engines
-  can index a blocked URL anyway on the strength of inbound links. Blocking is
-  the wrong tool for keeping a page out of an index.
+  Note what is *not* here: `/random/` carries a `noindex` meta tag and is
+  deliberately left crawlable anyway. A `Disallow` would stop the page being
+  fetched, so the `noindex` would never be read, and search engines can index a
+  blocked URL regardless on the strength of inbound links. Blocking is the
+  wrong tool for keeping a page out of an index.
+
+  `/search/` has no `noindex` and is not blocked here either. Whether it should
+  be kept out of the index is a separate question from crawl policy; see #175.
 */ -}}
 User-agent: *
 Allow: /

--- a/themes/reborn/layouts/robots.txt
+++ b/themes/reborn/layouts/robots.txt
@@ -1,0 +1,23 @@
+{{/* The crawl policy for the whole site. Enabled by `enableRobotsTXT` in
+  hugo.yaml; without that flag Hugo does not render this template at all and the
+  URL 404s, which is the state the site shipped in for years.
+
+  This is a template rather than `static/robots.txt` for one reason: the
+  `Sitemap:` line has to be an absolute URL, and a hardcoded one silently
+  becomes a lie the day `baseURL` changes. Building it with `absURL` means the
+  two cannot disagree.
+
+  The policy is deliberately open to every crawler, including AI training
+  crawlers. The reasoning, and what we would have to see to change our minds,
+  is in decisions/ai-crawlers.md.
+
+  Note what is *not* here: `/random/` and `/search/` carry `noindex` meta tags
+  and are deliberately left crawlable. A `Disallow` would prevent those pages
+  from being fetched, so the `noindex` would never be read, and search engines
+  can index a blocked URL anyway on the strength of inbound links. Blocking is
+  the wrong tool for keeping a page out of an index.
+*/ -}}
+User-agent: *
+Allow: /
+
+Sitemap: {{ "sitemap.xml" | absURL }}


### PR DESCRIPTION
Part of #144. First of five units of work on search/AI-index discoverability.

## The gap

`https://mikezornek.com/robots.txt` returns **404**. No crawler has ever been told where `sitemap.xml` lives, and the site has no stated crawl policy.

Worth noting: #15 ("add robots.txt") was closed without the file ever landing.

## What this does

Turns on `enableRobotsTXT` and adds `themes/reborn/layouts/robots.txt`. Output:

```
User-agent: *
Allow: /

Sitemap: https://mikezornek.com/sitemap.xml
```

## Two things to look at in review

**Why a template instead of `static/robots.txt`.** The `Sitemap:` line must be an absolute URL. Hardcoding one in a static file makes it a silent lie the day `baseURL` changes; `absURL` means the two cannot disagree.

**Why nothing is `Disallow`ed.** `/random/` and `/search/` carry `<meta name="robots" content="noindex">`. Blocking them in `robots.txt` would be counterproductive — a blocked page can't be fetched, so the `noindex` is never read, and search engines can still index the URL from inbound links. Leaving them crawlable is what makes the `noindex` work.

## The AI crawler stance

`decisions/ai-crawlers.md` records the decision to allow every crawler, including training crawlers, along with the alternatives rejected and what would reverse the call.

Short version: the blog exists so Elixir people know who Mike is, and models that have read it distribute exactly that. Blocking training crawlers also would not keep the site out of AI Overviews, which are built from the regular Googlebot index — `Google-Extended` only opts out of Gemini training. And #100, the one prior objection to AI crawling, was about Render bandwidth cost and was resolved by enabling billing.

## Verified

`hugo --cleanDestinationDir` renders `public/robots.txt` with the absolute sitemap URL and no leading blank line. Prettier clean.

## Not in this PR

Sitemap submission to Google/Bing, IndexNow, structured data, `llms.txt`. Each lands separately.