### PR TITLE
Record where the site is registered with search engines, add IndexNow

### DIFF
--- a/bin/indexnow.sh
+++ b/bin/indexnow.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# Tell IndexNow-participating search engines that a URL just changed, so they
+# crawl it now instead of waiting to rediscover it from the sitemap. Bing,
+# Yandex, Seznam, and Naver share one endpoint; a single call reaches all of
+# them. Bing's index also feeds DuckDuckGo, which is most of why this is worth
+# running at all.
+#
+# Run it by hand after a deploy is live, as part of the promotion routine in
+# playbook/promotion.md:
+#
+#   bin/indexnow.sh https://mikezornek.com/posts/2026/7/my-new-post/
+#
+# Deliberately NOT wired into bin/build.sh. That script runs before Render
+# publishes, so a ping from there announces URLs that are not live yet, and
+# IndexNow records the failed fetch. build.sh also runs on a fresh checkout with
+# no previous public/, so it has no way to know which URLs actually changed and
+# would have to ping all ~500 every deploy.
+#
+# Because pinging a URL that is not live is the specific failure this avoids,
+# the script refuses to send anything until it has seen a 200 from every URL.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly HOST="mikezornek.com"
+readonly KEY="509ce3a92525b2bfc2bdba120987afa2"
+readonly KEY_LOCATION="https://${HOST}/${KEY}.txt"
+readonly ENDPOINT="https://api.indexnow.org/indexnow"
+
+if [ "$#" -eq 0 ]; then
+  cat >&2 <<USAGE
+usage: bin/indexnow.sh <url> [url ...]
+
+Submits one or more https://${HOST}/ URLs to IndexNow.
+Every URL must already be live; the script checks before submitting.
+USAGE
+  exit 64
+fi
+
+# Refuse anything that is not one of our own https URLs. IndexNow answers 422
+# for a host mismatch, but catching it here gives a clearer message and avoids
+# burning a request.
+for url in "$@"; do
+  case "$url" in
+    "https://${HOST}/"*) ;;
+    *)
+      echo "ERROR: not a https://${HOST}/ URL: ${url}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# The whole reason this is a manual step: confirm the deploy actually landed.
+echo "Checking that every URL is live..."
+for url in "$@"; do
+  status="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "$url")"
+  if [ "$status" != "200" ]; then
+    echo "ERROR: ${url} returned ${status}, expected 200." >&2
+    echo "If you just pushed, the Render deploy may still be building." >&2
+    exit 1
+  fi
+  echo "  200  ${url}"
+done
+
+# Confirm the key file is reachable too. IndexNow fetches it to prove we own the
+# domain, and a 403 from the API with no explanation is a miserable thing to
+# debug later.
+key_status="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "$KEY_LOCATION")"
+if [ "$key_status" != "200" ]; then
+  echo "ERROR: key file ${KEY_LOCATION} returned ${key_status}, expected 200." >&2
+  exit 1
+fi
+
+# Build the urlList array without needing jq, which is not guaranteed present.
+url_list=""
+for url in "$@"; do
+  if [ -n "$url_list" ]; then
+    url_list="${url_list},"
+  fi
+  url_list="${url_list}\"${url}\""
+done
+
+payload="{\"host\":\"${HOST}\",\"key\":\"${KEY}\",\"keyLocation\":\"${KEY_LOCATION}\",\"urlList\":[${url_list}]}"
+
+echo "Submitting $# URL(s) to IndexNow..."
+response="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+  -X POST "$ENDPOINT" \
+  -H 'Content-Type: application/json; charset=utf-8' \
+  -d "$payload")"
+
+case "$response" in
+  200) echo "OK (200): submitted." ;;
+  202) echo "OK (202): accepted, key validation pending. Normal on first use." ;;
+  400) echo "FAILED (400): bad request format." >&2; exit 1 ;;
+  403) echo "FAILED (403): key rejected. Check ${KEY_LOCATION} contains exactly the key." >&2; exit 1 ;;
+  422) echo "FAILED (422): URLs do not belong to ${HOST}, or key schema mismatch." >&2; exit 1 ;;
+  429) echo "FAILED (429): rate limited. Wait before retrying." >&2; exit 1 ;;
+  *) echo "FAILED (${response}): unexpected response." >&2; exit 1 ;;
+esac

--- a/playbook/promotion.md
+++ b/playbook/promotion.md
@@ -2,6 +2,23 @@
 
 After posting something I am particularly proud of I tend to share it for more exposure.
 
+## First, once the deploy is live
+
+Ping the search indexes so they crawl the new post now instead of waiting to
+rediscover it:
+
+```bash
+bin/indexnow.sh https://mikezornek.com/posts/2026/7/my-new-post/
+```
+
+Reaches Bing (and therefore DuckDuckGo), Yandex, Seznam, and Naver in one call.
+Google does not participate. The script refuses to submit until it has seen a
+200 from the URL, so if it complains, the Render deploy is probably still
+building — wait and re-run. See `playbook/search-consoles.md` for the wider
+picture of what is registered where.
+
+## Then share it
+
 Some of the places include:
 
 - Personal Mastodon

--- a/playbook/search-consoles.md
+++ b/playbook/search-consoles.md
@@ -1,0 +1,106 @@
+# Search consoles and index submission
+
+Where this site is registered with search engines, how each registration was
+verified, and what to re-check.
+
+This file exists because issue #144 opened with a question nobody could answer:
+"Google Search Console — exists, but is the sitemap actually submitted?" That is
+not a thing that should require guessing. Neither is the fate of #15 ("add
+robots.txt"), which was closed without the file ever landing. **When you do any
+of the one-time steps below, update this file in the same sitting.** A checklist
+in an issue disappears when the issue closes; this does not.
+
+## What the site publishes for crawlers
+
+| Artifact      | URL                                                           | Notes                                                                                |
+| ------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Sitemap       | `https://mikezornek.com/sitemap.xml`                          | ~497 URLs, per-page `lastmod`. Hugo generates it.                                    |
+| Robots policy | `https://mikezornek.com/robots.txt`                           | Allows everything, advertises the sitemap. See `decisions/ai-crawlers.md`.           |
+| RSS           | `https://mikezornek.com/index.xml`                            | Full archive, full post bodies.                                                      |
+| IndexNow key  | `https://mikezornek.com/509ce3a92525b2bfc2bdba120987afa2.txt` | Proves domain ownership to IndexNow. Contents must be exactly the key, nothing else. |
+
+## Registrations
+
+Status is what has actually been confirmed, not what was intended.
+
+### Google Search Console
+
+- **Status:** account exists. **Sitemap submission unconfirmed.**
+- **To confirm:** Search Console → Indexing → Sitemaps. `sitemap.xml` should be
+  listed with a recent "Last read" date and status Success.
+- **If missing:** add `sitemap.xml` in that screen. One-time.
+- **Also pull while you are in there:** the URL list behind the "Blocked due to
+  other 4xx issue" warning (Indexing → Pages → click the reason → Export). That
+  report is the only way to diagnose #56 — the problem is not reproducible from
+  outside. Verified 2026-07-30: no bot blocking under a Googlebot user agent, no
+  rate limiting across a 25-request burst, and missing pages return clean 404s.
+  Paste the export into #56.
+- **Worth knowing:** Search Console reports are sticky. If the 4xx episode was a
+  past incident that has since been fixed, the warning persists until you hit
+  Validate Fix. So the export may describe a problem that no longer exists.
+
+### Bing Webmaster Tools
+
+- **Status:** unknown. Assume not set up.
+- **Why it matters more than Bing's market share suggests:** Bing's index feeds
+  DuckDuckGo and several AI answer engines.
+- **To set up:** sign in at <https://www.bing.com/webmasters> and use "Import
+  from Google Search Console" — it carries over site verification and sitemaps
+  in one step, which is much less work than verifying the domain again.
+- **Then:** confirm `sitemap.xml` is listed, and check the IndexNow section for
+  submission stats.
+
+### IndexNow
+
+- **Status:** key file ships with the site; script is in the repo. First real
+  submission happens the next time a post goes out.
+- **How to use:** after a deploy is live, `bin/indexnow.sh <url>`. This is a
+  step in `playbook/promotion.md`, not part of the build — see the comment at
+  the top of the script for why.
+- **Reaches:** Bing, Yandex, Seznam, and Naver share one endpoint. Google does
+  not participate.
+- **Expect a 202 on first use.** That means accepted, key validation pending. It
+  is not an error.
+
+### Kagi
+
+- **Status:** nothing submitted.
+- **Why bother:** Kagi was the single largest search referrer in the first
+  Signal Log week (14 visitors, more than Google and DuckDuckGo combined).
+- **There is no webmaster console.** Kagi is largely a metasearch layer over
+  "anonymized API calls to worldwide search engines"
+  (<https://help.kagi.com/kagi/search-details/search-sources.html>), so most
+  Kagi visibility is downstream of Google and Bing. Fixing those fixes Kagi.
+- **But there is one submission path:** Kagi Small Web
+  (<https://github.com/kagisearch/smallweb>) accepts personal blog RSS feeds by
+  pull request against `smallweb.txt`. This site meets every criterion —
+  English, single-author personal blog, posts within 12 months, no ads, no
+  popups.
+- **The catch:** a self-submission must add **at least two other new sites in
+  the same commit.** Pick two personal blogs worth surfacing.
+
+### DuckDuckGo
+
+- **Nothing to do.** No submission tool. Its results come from Bing's index, so
+  Bing Webmaster Tools is the lever.
+
+## Outstanding one-time work
+
+- [ ] Confirm `sitemap.xml` is submitted in Google Search Console
+- [ ] Export the #56 "Blocked due to other 4xx" URL list and paste it into #56
+- [ ] Set up Bing Webmaster Tools via Import from Google Search Console
+- [ ] Confirm `sitemap.xml` is listed in Bing Webmaster Tools
+- [ ] Open the Kagi Small Web PR (this site plus two others)
+
+## Re-check ritual
+
+Worth ten minutes a couple of times a year, or any time search referrals in the
+Signal Log look wrong:
+
+1. `curl -sI https://mikezornek.com/robots.txt` returns 200.
+2. `curl -sI https://mikezornek.com/sitemap.xml` returns 200.
+3. `curl -s https://mikezornek.com/509ce3a92525b2bfc2bdba120987afa2.txt` prints
+   the key and nothing else.
+4. Google Search Console: sitemap "Last read" is recent; no new indexing errors.
+5. Bing Webmaster Tools: same, plus IndexNow submissions are being accepted.
+6. Update the Status lines above with what you found and the date.

--- a/playbook/search-consoles.md
+++ b/playbook/search-consoles.md
@@ -12,12 +12,22 @@ in an issue disappears when the issue closes; this does not.
 
 ## What the site publishes for crawlers
 
-| Artifact      | URL                                                           | Notes                                                                                                             |
-| ------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| Sitemap       | `https://mikezornek.com/sitemap.xml`                          | ~497 URLs, per-page `lastmod`. Hugo generates it.                                                                 |
-| Robots policy | `https://mikezornek.com/robots.txt`                           | Allows everything, advertises the sitemap. Lands in #167; 404s until that merges. See `decisions/ai-crawlers.md`. |
-| RSS           | `https://mikezornek.com/index.xml`                            | Full archive, full post bodies.                                                                                   |
-| IndexNow key  | `https://mikezornek.com/509ce3a92525b2bfc2bdba120987afa2.txt` | Proves domain ownership to IndexNow. Contents must be exactly the key, nothing else.                              |
+| Artifact      | URL                                                           | Notes                                                                                |
+| ------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Sitemap       | `https://mikezornek.com/sitemap.xml`                          | ~497 URLs, per-page `lastmod`. Hugo generates it.                                    |
+| Robots policy | `https://mikezornek.com/robots.txt`                           | Allows everything, advertises the sitemap. See `decisions/ai-crawlers.md`.           |
+| RSS           | `https://mikezornek.com/index.xml`                            | Full archive, full post bodies.                                                      |
+| IndexNow key  | `https://mikezornek.com/509ce3a92525b2bfc2bdba120987afa2.txt` | Proves domain ownership to IndexNow. Contents must be exactly the key, nothing else. |
+
+**Last verified live: 2026-07-30.** `robots.txt` serves 200 as `text/plain`, its
+`Sitemap:` line resolves to a 200 XML document, and it is byte-identical when
+fetched under a Googlebot user agent. `/random/` is crawlable and still carries
+its `noindex` tag, which is the arrangement that lets the tag be read at all.
+The IndexNow key file is not live yet — it ships with this change.
+
+One caching note: Cloudflare fronts these with `s-maxage=300`, so an edit to
+`robots.txt` can take up to five minutes to reach crawlers. A stale response
+right after a deploy is expected rather than a bug.
 
 ## Registrations
 
@@ -97,8 +107,7 @@ Status is what has actually been confirmed, not what was intended.
 Worth ten minutes a couple of times a year, or any time search referrals in the
 Signal Log look wrong:
 
-1. `curl -sI https://mikezornek.com/robots.txt` returns 200. (Until #167 merges
-   and deploys, this is a 404 — that is the gap #167 closes, not a regression.)
+1. `curl -sI https://mikezornek.com/robots.txt` returns 200.
 2. `curl -sI https://mikezornek.com/sitemap.xml` returns 200.
 3. `curl -s https://mikezornek.com/509ce3a92525b2bfc2bdba120987afa2.txt` prints
    the key and nothing else.

--- a/playbook/search-consoles.md
+++ b/playbook/search-consoles.md
@@ -12,12 +12,12 @@ in an issue disappears when the issue closes; this does not.
 
 ## What the site publishes for crawlers
 
-| Artifact      | URL                                                           | Notes                                                                                |
-| ------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| Sitemap       | `https://mikezornek.com/sitemap.xml`                          | ~497 URLs, per-page `lastmod`. Hugo generates it.                                    |
-| Robots policy | `https://mikezornek.com/robots.txt`                           | Allows everything, advertises the sitemap. See `decisions/ai-crawlers.md`.           |
-| RSS           | `https://mikezornek.com/index.xml`                            | Full archive, full post bodies.                                                      |
-| IndexNow key  | `https://mikezornek.com/509ce3a92525b2bfc2bdba120987afa2.txt` | Proves domain ownership to IndexNow. Contents must be exactly the key, nothing else. |
+| Artifact      | URL                                                           | Notes                                                                                                             |
+| ------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Sitemap       | `https://mikezornek.com/sitemap.xml`                          | ~497 URLs, per-page `lastmod`. Hugo generates it.                                                                 |
+| Robots policy | `https://mikezornek.com/robots.txt`                           | Allows everything, advertises the sitemap. Lands in #167; 404s until that merges. See `decisions/ai-crawlers.md`. |
+| RSS           | `https://mikezornek.com/index.xml`                            | Full archive, full post bodies.                                                                                   |
+| IndexNow key  | `https://mikezornek.com/509ce3a92525b2bfc2bdba120987afa2.txt` | Proves domain ownership to IndexNow. Contents must be exactly the key, nothing else.                              |
 
 ## Registrations
 
@@ -97,7 +97,8 @@ Status is what has actually been confirmed, not what was intended.
 Worth ten minutes a couple of times a year, or any time search referrals in the
 Signal Log look wrong:
 
-1. `curl -sI https://mikezornek.com/robots.txt` returns 200.
+1. `curl -sI https://mikezornek.com/robots.txt` returns 200. (Until #167 merges
+   and deploys, this is a 404 — that is the gap #167 closes, not a regression.)
 2. `curl -sI https://mikezornek.com/sitemap.xml` returns 200.
 3. `curl -s https://mikezornek.com/509ce3a92525b2bfc2bdba120987afa2.txt` prints
    the key and nothing else.

--- a/playbook/search-consoles.md
+++ b/playbook/search-consoles.md
@@ -35,16 +35,41 @@ Status is what has actually been confirmed, not what was intended.
 
 ### Google Search Console
 
-- **Status:** account exists. **Sitemap submission unconfirmed.**
-- **To confirm:** Search Console → Indexing → Sitemaps. `sitemap.xml` should be
-  listed with a recent "Last read" date and status Success.
-- **If missing:** add `sitemap.xml` in that screen. One-time.
-- **Also pull while you are in there:** the URL list behind the "Blocked due to
-  other 4xx issue" warning (Indexing → Pages → click the reason → Export). That
-  report is the only way to diagnose #56 — the problem is not reproducible from
-  outside. Verified 2026-07-30: no bot blocking under a Googlebot user agent, no
-  rate limiting across a 25-request burst, and missing pages return clean 404s.
-  Paste the export into #56.
+- **Status:** verified 2026-07-31 under the **zorn@zornlabs.com** Google
+  account, as a **Domain property** (`sc-domain:mikezornek.com`), which covers
+  http, https, and all subdomains at once.
+- **Verification is a DNS TXT record at the apex,** `@` on mikezornek.com in
+  Hover. It must be `@`, not `*`. A wildcard TXT never answers for the apex
+  itself, so Google reads it as no record at all and verification fails. That
+  mistake cost an evening. Hover took about three minutes to publish the record
+  before `dig +short TXT mikezornek.com` returned it.
+- **Sitemap: submitted, but it was stale.** The answer to the question that
+  opened #144 is that a sitemap had been submitted on 2020-08-22, pointing at
+  `http://mikezornek.com/sitemap.xml`. That URL now 301s to https. Google last
+  read it 2023-01-15 and knew about 430 pages, against 497 in the live sitemap.
+  The https URL was submitted 2026-07-31 and the http row removed. Google read
+  it the same day: status Success, 497 discovered pages, matching the live file
+  exactly. Resubmission is read within minutes, not the day or two the indexing
+  reports need.
+- **The lesson worth keeping:** "a sitemap is listed" is not the same as "the
+  right sitemap is being read." Check the Last read date and the discovered page
+  count against `curl -s https://mikezornek.com/sitemap.xml | grep -c "<loc>"`,
+  not just the green Success label.
+- **The #56 4xx export is not available yet.** Indexing → Pages reads
+  "Processing data, please check again in a day or so" as of 2026-07-31, because
+  the Domain property was verified the same day and its reports have not
+  backfilled. Check again after 2026-08-02; tracked in #177. That report is the
+  only way to
+  diagnose #56, since the problem is not reproducible from outside: verified
+  2026-07-30 that there is no bot blocking under a Googlebot user agent, no rate
+  limiting across a 25-request burst, and that missing pages return clean 404s.
+- **Open question about where the 4xx warning came from.** This property's
+  reports were empty on the day it was verified, so the warning quoted in #56
+  must have been seen somewhere else, most likely an older URL-prefix property
+  (`http://mikezornek.com/`) under an account nobody can currently find. The
+  2020 sitemap submission points the same way. If the new property never shows a
+  4xx warning once it backfills, that is a real possibility rather than a
+  reporting glitch, and #56 may simply be describing a property that is gone.
 - **Worth knowing:** Search Console reports are sticky. If the 4xx episode was a
   past incident that has since been fixed, the warning persists until you hit
   Validate Fix. So the export may describe a problem that no longer exists.
@@ -74,20 +99,30 @@ Status is what has actually been confirmed, not what was intended.
 
 ### Kagi
 
-- **Status:** nothing submitted.
-- **Why bother:** Kagi was the single largest search referrer in the first
-  Signal Log week (14 visitors, more than Google and DuckDuckGo combined).
+- **Status:** nothing submitted, and nothing needs to be. Kagi referrals are
+  already arriving without any registration.
+- **Kagi was the single largest search referrer** in the first Signal Log week
+  (14 visitors, more than Google and DuckDuckGo combined). Check the current
+  number with this saved Plausible filter:
+  <https://plausible.io/mikezornek.com?f=is,channel,Organic%20Search&f=is,source,Kagi>
 - **There is no webmaster console.** Kagi is largely a metasearch layer over
   "anonymized API calls to worldwide search engines"
   (<https://help.kagi.com/kagi/search-details/search-sources.html>), so most
   Kagi visibility is downstream of Google and Bing. Fixing those fixes Kagi.
-- **But there is one submission path:** Kagi Small Web
-  (<https://github.com/kagisearch/smallweb>) accepts personal blog RSS feeds by
-  pull request against `smallweb.txt`. This site meets every criterion —
-  English, single-author personal blog, posts within 12 months, no ads, no
-  popups.
-- **The catch:** a self-submission must add **at least two other new sites in
-  the same commit.** Pick two personal blogs worth surfacing.
+
+**Two surfaces, do not confuse them.** The referrals above come from Kagi _main_
+search, which takes no submission. Kagi Small Web is a separate, much smaller
+discovery surface, and being in main search does not put you in it.
+
+- **Small Web: already listed, nothing to do.** `https://mikezornek.com/index.xml`
+  is line 25664 of `smallweb.txt` in
+  <https://github.com/kagisearch/smallweb>. Verified on `main` 2026-07-31. How
+  or when it got added is unknown, so do not assume it was deliberate.
+- **If it ever disappears,** the list takes personal blog RSS feeds by pull
+  request against `smallweb.txt`, and this site meets every criterion: English,
+  single-author personal blog, posts within 12 months, no ads, no popups. The
+  catch is that a self-submission must add **at least two other new sites in the
+  same commit**, so it is a small chore, not a one-liner.
 
 ### DuckDuckGo
 
@@ -96,11 +131,14 @@ Status is what has actually been confirmed, not what was intended.
 
 ## Outstanding one-time work
 
-- [ ] Confirm `sitemap.xml` is submitted in Google Search Console
-- [ ] Export the #56 "Blocked due to other 4xx" URL list and paste it into #56
+- [x] Confirm `sitemap.xml` is submitted in Google Search Console (2026-07-31:
+      was stale on the http URL, resubmitted as https, reads Success at 497
+      pages)
+- [ ] After 2026-08-02, once Page indexing backfills: export the #56 "Blocked
+      due to other 4xx" URL list and paste it into #56, or record that the
+      warning does not appear on this property. Tracked in #177.
 - [ ] Set up Bing Webmaster Tools via Import from Google Search Console
 - [ ] Confirm `sitemap.xml` is listed in Bing Webmaster Tools
-- [ ] Open the Kagi Small Web PR (this site plus two others)
 
 ## Re-check ritual
 

--- a/playbook/search-consoles.md
+++ b/playbook/search-consoles.md
@@ -76,19 +76,36 @@ Status is what has actually been confirmed, not what was intended.
 
 ### Bing Webmaster Tools
 
-- **Status:** unknown. Assume not set up.
+- **Status:** set up 2026-07-31 by signing in at
+  <https://www.bing.com/webmasters> with Google, on the same zornlabs.com
+  identity as Search Console. The property is `https://mikezornek.com/`.
 - **Why it matters more than Bing's market share suggests:** Bing's index feeds
   DuckDuckGo and several AI answer engines.
-- **To set up:** sign in at <https://www.bing.com/webmasters> and use "Import
-  from Google Search Console" — it carries over site verification and sitemaps
-  in one step, which is much less work than verifying the domain again.
-- **Then:** confirm `sitemap.xml` is listed, and check the IndexNow section for
-  submission stats.
+- **"Import from Google Search Console" does not import the sitemap.** It
+  carries verification across, which is the tedious part, but the Sitemaps
+  screen was still empty afterward (0 rows) and the home page banner asks you to
+  submit one. `https://mikezornek.com/sitemap.xml` was submitted by hand on
+  2026-07-31 and was processing at the end of the session. Confirm it landed and
+  reads 497 URLs.
+- **Bing has no equivalent of Google's Domain property,** so the property is
+  scheme-specific. Check it says `https://`. An `http://` property would repeat
+  the mistake that left the Google sitemap unread from 2023 to 2026.
+- **Reports take up to 48 hours** to populate after setup, same idea as Google's
+  backfill.
+- **Then:** check the IndexNow section for submission stats, but not until the
+  key file is actually live. See below.
 
 ### IndexNow
 
-- **Status:** key file ships with the site; script is in the repo. First real
-  submission happens the next time a post goes out.
+- **Status:** key file and script are in the repo, but **the key is not live
+  until this branch merges to `main`.** Confirmed 404 on 2026-07-31. First real
+  submission happens the next time a post goes out after that deploy.
+- **Do not let Bing generate a key for you.** Bing's IndexNow screen offers to
+  mint one. Taking it would leave Bing expecting a key the site does not serve,
+  since `509ce3a92525b2bfc2bdba120987afa2` is already committed in `static/`.
+- **Check it is live before the first submission:**
+  `curl -s -o /dev/null -w "%{http_code}" https://mikezornek.com/509ce3a92525b2bfc2bdba120987afa2.txt`
+  should print 200.
 - **How to use:** after a deploy is live, `bin/indexnow.sh <url>`. This is a
   step in `playbook/promotion.md`, not part of the build — see the comment at
   the top of the script for why.
@@ -137,8 +154,12 @@ discovery surface, and being in main search does not put you in it.
 - [ ] After 2026-08-02, once Page indexing backfills: export the #56 "Blocked
       due to other 4xx" URL list and paste it into #56, or record that the
       warning does not appear on this property. Tracked in #177.
-- [ ] Set up Bing Webmaster Tools via Import from Google Search Console
-- [ ] Confirm `sitemap.xml` is listed in Bing Webmaster Tools
+- [x] Set up Bing Webmaster Tools via Import from Google Search Console
+      (2026-07-31, https property, signed in with Google)
+- [ ] Confirm the hand-submitted `sitemap.xml` finished processing in Bing and
+      reads 497 URLs
+- [ ] After this branch merges, confirm the IndexNow key file returns 200 before
+      the first `bin/indexnow.sh` run
 
 ## Re-check ritual
 

--- a/static/509ce3a92525b2bfc2bdba120987afa2.txt
+++ b/static/509ce3a92525b2bfc2bdba120987afa2.txt
@@ -1,0 +1,1 @@
+509ce3a92525b2bfc2bdba120987afa2


### PR DESCRIPTION
Part of #144. Second of five units of work on search/AI-index discoverability.

## Why a doc, not a checklist

#144 opened with a question that should not have been hard: *"Google Search Console — exists, but is the sitemap actually submitted?"* Nobody knew. And #15 ("add robots.txt") was closed with no file ever landing.

A checklist inside an issue is something you can close without doing, and it vanishes when the issue does. `playbook/search-consoles.md` persists, sits next to `promotion.md`, and is written to be updated in place as things get confirmed.

It covers Google Search Console, Bing Webmaster Tools, IndexNow, Kagi, and DuckDuckGo — with each **Status** line stating what has actually been verified rather than what was intended.

## Two findings worth calling out

**Kagi is more actionable than the issue assumed.** There is no webmaster console, and per [Kagi's own docs](https://help.kagi.com/kagi/search-details/search-sources.html) it is largely a metasearch layer over "anonymized API calls to worldwide search engines" — so most Kagi visibility is downstream of Google and Bing. But [Kagi Small Web](https://github.com/kagisearch/smallweb) accepts personal blog RSS feeds by PR, and this site meets every criterion. Catch: a self-submission must add two other new sites in the same commit. Given Kagi was the top search referrer in the first Signal Log week, this may be the highest-ROI item in the whole #144 effort.

**#56 is not reproducible from outside.** Verified 2026-07-30: no bot blocking under a Googlebot user agent, no rate limiting across a 25-request burst, clean 404s on missing pages. It needs the URL export from Search Console, which is now a step in the doc. Also noted there: GSC reports are sticky, so the warning may describe an already-fixed incident.

## IndexNow

`bin/indexnow.sh` plus `static/509ce3a92525b2bfc2bdba120987afa2.txt`, and one new section in `promotion.md`.

**Why it is not in `bin/build.sh`,** which is what #144 suggested: that script runs *before* Render publishes. A ping from there announces URLs that are not live yet, and IndexNow records the failed fetch — worse than not pinging. It also runs on a fresh checkout with no previous `public/`, so it cannot know which URLs changed; it would have to ping all ~497 every deploy.

So the script guards the exact failure it is avoiding: **it refuses to submit until it has seen a 200 from every URL and from the key file.** If the deploy is still building, it stops and says so.

## Verified

```
$ bin/indexnow.sh https://example.com/foo
ERROR: not a https://mikezornek.com/ URL: https://example.com/foo

$ bin/indexnow.sh
usage: bin/indexnow.sh <url> [url ...]

$ bin/indexnow.sh https://mikezornek.com/now/
Checking that every URL is live...
  200  https://mikezornek.com/now/
ERROR: key file https://mikezornek.com/509ce3a92525b2bfc2bdba120987afa2.txt returned 404, expected 200.
```

That last one is correct behaviour — the key file only goes live when this merges. **The first real submission cannot happen until after this deploys.** `bash -n` clean; Hugo publishes the key file with no trailing newline.

`promotion.md` was already failing `prettier --check` on `main`, so I formatted only the new file rather than mixing unrelated churn into this PR.

## Still yours to do

The doc's "Outstanding one-time work" section lists the five browser steps: confirm the GSC sitemap, export the #56 URLs, set up Bing via Import from GSC, confirm the Bing sitemap, open the Kagi Small Web PR.