### PR TITLE
Render the Follow page from data/profiles.yaml

### DIFF
--- a/content/follow.md
+++ b/content/follow.md
@@ -8,15 +8,12 @@ aliases: /feeds/
 
 ## RSS Feeds
 
-- [Mike Zornek.com RSS](https://mikezornek.com/index.xml)
-- [Mastodon @zorn@jawns.com RSS](https://jawns.club/@zorn.rss)
-- [Personal YouTube Channel RSS](https://www.youtube.com/feeds/videos.xml?channel_id=UCZVgPg6CmFAA4dHyKklG0Nw)
+{{< profile-feeds >}}
 
 ## Platform Accounts
 
-- [Mastodon @zorn@jawns.com](https://jawns.club/@zorn)
-- [Bluesky](https://bsky.app/profile/mikezornek.com)
-- [Personal YouTube Channel](https://www.youtube.com/channel/UCZVgPg6CmFAA4dHyKklG0Nw)
-- [Personal GitHub Profile](https://github.com/zorn)
-- [LinkedIn Profile](https://www.linkedin.com/in/mikezornek/)
-- [GoodReads](https://www.goodreads.com/user/show/30324035-mike-zornek)
+{{< profile-accounts >}}
+
+<!-- Both lists render from data/profiles.yaml, which is also the source for the
+`sameAs` array in this site's structured data. Add or change an account there,
+not here. -->

--- a/data/profiles.yaml
+++ b/data/profiles.yaml
@@ -1,0 +1,37 @@
+# Mike's accounts on other platforms: the single source for both the visible
+# Follow page and the `sameAs` array in the site's structured data.
+#
+# Why one list instead of two: `sameAs` tells search engines "the entity
+# described on this site is the same entity as these external profiles." A
+# `sameAs` array that disagrees with the links a reader can actually see is
+# worse than no `sameAs` at all — it asserts a connection the site does not
+# make. Keeping both renderings on one list means they cannot drift.
+#
+# Same reasoning as docs/adr/0001-curated-list-via-data-file.md: a curated list
+# where each entry carries display text belongs in a data file, not scattered
+# across prose and templates.
+#
+# Order here IS display order on the Follow page.
+# Each entry:
+#   name - display text for the link. Also used for the feed link, suffixed
+#          with " RSS".
+#   url  - the profile page. Every url in this list ends up in `sameAs`, so
+#          only add things that are genuinely a profile of Mike. A feed, a
+#          project page, or someone else's site does not belong here.
+#   feed - optional RSS/Atom URL for that account. Entries with one are also
+#          listed in the Follow page's RSS section.
+accounts:
+  - name: Mastodon @zorn@jawns.club
+    url: https://jawns.club/@zorn
+    feed: https://jawns.club/@zorn.rss
+  - name: Bluesky
+    url: https://bsky.app/profile/mikezornek.com
+  - name: Personal YouTube Channel
+    url: https://www.youtube.com/channel/UCZVgPg6CmFAA4dHyKklG0Nw
+    feed: https://www.youtube.com/feeds/videos.xml?channel_id=UCZVgPg6CmFAA4dHyKklG0Nw
+  - name: Personal GitHub Profile
+    url: https://github.com/zorn
+  - name: LinkedIn Profile
+    url: https://www.linkedin.com/in/mikezornek/
+  - name: GoodReads
+    url: https://www.goodreads.com/user/show/30324035-mike-zornek

--- a/themes/reborn/layouts/shortcodes/profile-accounts.html
+++ b/themes/reborn/layouts/shortcodes/profile-accounts.html
@@ -6,7 +6,7 @@
   reader is a claim the site does not back up.
 */}}
 <ul>
-  {{- range site.Data.profiles.accounts }}
+  {{- range hugo.Data.profiles.accounts }}
     <li><a href="{{ .url }}">{{ .name }}</a></li>
   {{- end }}
 </ul>

--- a/themes/reborn/layouts/shortcodes/profile-accounts.html
+++ b/themes/reborn/layouts/shortcodes/profile-accounts.html
@@ -1,0 +1,12 @@
+{{/* The Follow page's "Platform Accounts" list.
+
+  Every entry rendered here also lands in the `sameAs` array of the site's
+  structured data, which is the point of driving both from
+  data/profiles.yaml — an account claimed to a search engine but not shown to a
+  reader is a claim the site does not back up.
+*/}}
+<ul>
+  {{- range site.Data.profiles.accounts }}
+    <li><a href="{{ .url }}">{{ .name }}</a></li>
+  {{- end }}
+</ul>

--- a/themes/reborn/layouts/shortcodes/profile-feeds.html
+++ b/themes/reborn/layouts/shortcodes/profile-feeds.html
@@ -1,0 +1,21 @@
+{{/* The Follow page's "RSS Feeds" list: this site's own feed, then a feed for
+  every entry in data/profiles.yaml that has one.
+
+  Rendered from the same data file as the Platform Accounts list below it and
+  as the `sameAs` array in the site's structured data, so the three cannot
+  disagree. See the comment at the top of data/profiles.yaml.
+*/}}
+<ul>
+  {{/* This site's feed is not a platform account, so it is not in the data
+    file. Hugo already knows its URL, so there is nothing to keep in sync.
+  */}}
+  {{- with site.Home.OutputFormats.Get "RSS" }}
+    <li><a href="{{ .Permalink }}">Mike Zornek.com RSS</a></li>
+  {{- end }}
+  {{- range site.Data.profiles.accounts }}
+    {{- $account := . }}
+    {{- with .feed }}
+      <li><a href="{{ . }}">{{ $account.name }} RSS</a></li>
+    {{- end }}
+  {{- end }}
+</ul>

--- a/themes/reborn/layouts/shortcodes/profile-feeds.html
+++ b/themes/reborn/layouts/shortcodes/profile-feeds.html
@@ -12,7 +12,7 @@
   {{- with site.Home.OutputFormats.Get "RSS" }}
     <li><a href="{{ .Permalink }}">Mike Zornek.com RSS</a></li>
   {{- end }}
-  {{- range site.Data.profiles.accounts }}
+  {{- range hugo.Data.profiles.accounts }}
     {{- $account := . }}
     {{- with .feed }}
       <li><a href="{{ . }}">{{ $account.name }} RSS</a></li>


### PR DESCRIPTION
Part of #144. Third of five. **Pure refactor — no new behaviour.** It exists to unblock the structured-data PR that follows.

## Why

The next PR adds a `sameAs` array to the site's structured data — the property that tells search engines "the person described on this site is the same person as these external profiles." It needs the same six URLs currently hand-written into `content/follow.md`.

Two hand-maintained copies of one list eventually disagree, and this particular disagreement is worse than it sounds: a `sameAs` claiming an account the visible page doesn't link is a claim the site can't back up. Silent, too — nobody reads their own JSON-LD.

Same reasoning as ADR 0001: a curated list where each entry carries display text belongs in a data file.

## What changed

- `data/profiles.yaml` — six accounts, each with `name`, `url`, optional `feed`. Order is display order.
- `shortcodes/profile-feeds.html` and `shortcodes/profile-accounts.html`
- `content/follow.md` — the two hardcoded lists become two shortcode calls

The site's own RSS feed stays out of the data file: it isn't a platform account, it doesn't belong in `sameAs`, and Hugo already knows its URL via `site.Home.OutputFormats`.

## One real change, flagged

The page displayed the Mastodon handle as **`@zorn@jawns.com`** while linking to **`jawns.club`**. `hugo.yaml`'s `fediverse_creator` already had `@zorn@jawns.club`. Fixed in both spots.

## Verified

Rendered `<li>` elements diffed before and after. The only differences are the two intentional handle fixes:

```diff
2c2
< <li><a href="https://jawns.club/@zorn.rss">Mastodon @zorn@jawns.com RSS</a></li>
---
> <li><a href="https://jawns.club/@zorn.rss">Mastodon @zorn@jawns.club RSS</a></li>
4c4
< <li><a href="https://jawns.club/@zorn">Mastodon @zorn@jawns.com</a></li>
---
> <li><a href="https://jawns.club/@zorn">Mastodon @zorn@jawns.club</a></li>
```

Every URL and the ordering are byte-identical. Prettier clean, and re-diffed after formatting to confirm the go-template plugin didn't alter output (it reflowed a comment and an indent; rendered HTML unchanged).

## Trade-off worth naming

This turns a page you could edit as plain markdown into one that renders through shortcodes. Small loss of directness on a page touched rarely. The alternative — leave `follow.md` as prose and accept two lists — is defensible; this went the other way because the failure mode is invisible.