### PR TITLE
Declare a Person entity in JSON-LD and verify it on every build

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -76,3 +76,11 @@ node bin/og-images.mjs
 # posts had shipped broken paths this way before the check existed. See #159.
 echo "Verifying social images..."
 node bin/verify-og-images.mjs
+
+# Fail the build if the page's JSON-LD is malformed, incomplete, or references
+# an entity no node on that page declares. Structured data is never rendered, so
+# a mistake in it is invisible in a way even a broken og:image is not: nobody
+# sees a wrong share preview and reports it. Same class of silent failure as
+# #159, checked the same way. See decisions/structured-data.md.
+echo "Verifying structured data..."
+node bin/verify-structured-data.mjs

--- a/bin/verify-structured-data.mjs
+++ b/bin/verify-structured-data.mjs
@@ -47,11 +47,6 @@ const NOINDEX = /<meta\s+name="robots"\s+content="[^"]*noindex/i;
 // not posts and carry no BlogPosting.
 const POST_PATH = /^posts\/\d{4}\/\d{1,2}\/[^/]+\/index\.html$/;
 
-// Google rejects an Article headline over 110 characters. The longest post
-// title today is 97, so this is a guard against a future title rather than a
-// present failure.
-const MAX_HEADLINE = 110;
-
 const REQUIRED = {
   Person: ["name", "url", "sameAs"],
   ProfilePage: ["mainEntity"],
@@ -165,14 +160,6 @@ async function main() {
         }
 
         if (type === "BlogPosting") {
-          if (
-            typeof node.headline === "string" &&
-            node.headline.length > MAX_HEADLINE
-          ) {
-            errors.push(
-              `${page}  BlogPosting headline is ${node.headline.length} chars, over Google's ${MAX_HEADLINE} limit. Shorten the post title.`,
-            );
-          }
           const twitter = html.match(TWITTER_IMAGE)?.[1];
           if (twitter && node.image !== twitter) {
             errors.push(

--- a/bin/verify-structured-data.mjs
+++ b/bin/verify-structured-data.mjs
@@ -1,0 +1,246 @@
+// Asserts that the JSON-LD the built site emits is well formed, internally
+// consistent, and actually present where it is supposed to be.
+//
+// JSON-LD fails the same way the broken `og:image` paths in #159 did: silently.
+// Nothing renders wrong, no reader notices, and a typo can ship for a year. The
+// difference is that JSON-LD is worse — it is never displayed at all, so the
+// only way to see it is to go looking. This check is that looking, on every
+// build. There is no test suite in this repo; this stands in for one.
+//
+// What it checks, per rendered page:
+//
+//   1. Every `application/ld+json` block parses as JSON.
+//   2. Coverage: the homepage declares a ProfilePage, and every blog post
+//      declares a BlogPosting. A template regression that silently stopped
+//      emitting anything would otherwise pass, since "no markup" is not
+//      "invalid markup".
+//   3. Reference integrity: every `{"@id": ...}` reference resolves to a node
+//      declared in the same page's graph. This is the invariant the whole
+//      design rests on — see decisions/structured-data.md — and it is the one
+//      thing no amount of reading the template will confirm.
+//   4. Required properties are present on each node type.
+//   5. The BlogPosting `image` matches the page's `twitter:image`, proving the
+//      two really do come from the shared og/image-url.html partial.
+//
+// Usage: node bin/verify-structured-data.mjs [publish-dir]
+
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+const PUBLISH_DIR = process.argv[2] ?? "public";
+
+const LD_BLOCK =
+  /<script\s+type="application\/ld\+json"\s*>([\s\S]*?)<\/script>/g;
+
+const TWITTER_IMAGE = /<meta\s+name="twitter:image"\s+content="([^"]*)"/;
+
+// Same two exclusions verify-og-images.mjs makes, for the same reasons: Hugo
+// writes ~190 bare meta-refresh stubs for `aliases`, and /random/ is a
+// noindex bounce page with its own layout. Neither loads the head partial, so
+// neither has structured data, and that is correct rather than a defect.
+const ALIAS_STUB = /<meta\s+http-equiv="refresh"/i;
+const NOINDEX = /<meta\s+name="robots"\s+content="[^"]*noindex/i;
+
+// Content lives at content/posts/YYYY/M/slug/index.md, so the built post pages
+// are exactly posts/YYYY/M/slug/index.html. Anchoring on that shape excludes
+// the section list at /posts/ and the paginated /posts/page/N/ pages, which are
+// not posts and carry no BlogPosting.
+const POST_PATH = /^posts\/\d{4}\/\d{1,2}\/[^/]+\/index\.html$/;
+
+// Google rejects an Article headline over 110 characters. The longest post
+// title today is 97, so this is a guard against a future title rather than a
+// present failure.
+const MAX_HEADLINE = 110;
+
+const REQUIRED = {
+  Person: ["name", "url", "sameAs"],
+  ProfilePage: ["mainEntity"],
+  BlogPosting: [
+    "headline",
+    "datePublished",
+    "dateModified",
+    "author",
+    "publisher",
+    "image",
+    "url",
+  ],
+};
+
+function log(message) {
+  console.log(`[verify-schema] ${message}`);
+}
+
+async function* htmlFiles(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* htmlFiles(path);
+    } else if (entry.name.endsWith(".html")) {
+      yield path;
+    }
+  }
+}
+
+// Walks the parsed graph and separates the two kinds of object that carry an
+// `@id`. A node that also has `@type` is a *declaration* — it says what that
+// id is. One without a `@type` is a *reference* — it points at a declaration
+// and expects something else to supply the meaning. That distinction is the
+// whole basis of check 3.
+function collectIds(value, declared, referenced) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectIds(item, declared, referenced);
+    return;
+  }
+  if (value === null || typeof value !== "object") return;
+
+  if (typeof value["@id"] === "string") {
+    if (value["@type"]) {
+      declared.add(value["@id"]);
+    } else {
+      referenced.add(value["@id"]);
+    }
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (key === "@id" || key === "@type") continue;
+    collectIds(child, declared, referenced);
+  }
+}
+
+function nodesOf(parsed) {
+  const graph = parsed["@graph"];
+  return Array.isArray(graph) ? graph : [parsed];
+}
+
+async function main() {
+  const errors = [];
+  let pages = 0;
+  let skipped = 0;
+  let blocks = 0;
+  let postsSeen = 0;
+  let homeSeen = false;
+
+  for await (const file of htmlFiles(PUBLISH_DIR)) {
+    const html = await readFile(file, "utf8");
+    if (ALIAS_STUB.test(html) || NOINDEX.test(html)) {
+      skipped += 1;
+      continue;
+    }
+    pages += 1;
+
+    const rel = relative(PUBLISH_DIR, file);
+    const page = "/" + rel;
+    const isHome = rel === "index.html";
+    const isPost = POST_PATH.test(rel);
+
+    const parsedBlocks = [];
+    for (const [, body] of html.matchAll(LD_BLOCK)) {
+      blocks += 1;
+      try {
+        parsedBlocks.push(JSON.parse(body));
+      } catch (error) {
+        errors.push(`${page}  invalid JSON in ld+json block: ${error.message}`);
+      }
+    }
+
+    const types = new Set();
+    const declared = new Set();
+    const referenced = new Set();
+
+    for (const parsed of parsedBlocks) {
+      collectIds(parsed, declared, referenced);
+      for (const node of nodesOf(parsed)) {
+        if (!node || typeof node !== "object") continue;
+        const type = node["@type"];
+        types.add(type);
+
+        for (const property of REQUIRED[type] ?? []) {
+          const present =
+            node[property] !== undefined &&
+            node[property] !== null &&
+            node[property] !== "" &&
+            !(Array.isArray(node[property]) && node[property].length === 0);
+          if (!present) {
+            errors.push(`${page}  ${type} is missing required "${property}"`);
+          }
+        }
+
+        if (type === "BlogPosting") {
+          if (
+            typeof node.headline === "string" &&
+            node.headline.length > MAX_HEADLINE
+          ) {
+            errors.push(
+              `${page}  BlogPosting headline is ${node.headline.length} chars, over Google's ${MAX_HEADLINE} limit. Shorten the post title.`,
+            );
+          }
+          const twitter = html.match(TWITTER_IMAGE)?.[1];
+          if (twitter && node.image !== twitter) {
+            errors.push(
+              `${page}  BlogPosting image (${node.image}) does not match twitter:image (${twitter}). They should both come from og/image-url.html.`,
+            );
+          }
+        }
+      }
+    }
+
+    for (const id of referenced) {
+      if (!declared.has(id)) {
+        errors.push(
+          `${page}  references @id "${id}" but no node on this page declares it. Google parses each page on its own, so the reference is unresolvable here.`,
+        );
+      }
+    }
+
+    if (isHome) {
+      homeSeen = true;
+      if (!types.has("ProfilePage")) {
+        errors.push(`${page}  homepage declares no ProfilePage`);
+      }
+    }
+    if (isPost) {
+      postsSeen += 1;
+      if (!types.has("BlogPosting")) {
+        errors.push(`${page}  post declares no BlogPosting`);
+      }
+    }
+  }
+
+  log(
+    `${pages} pages, ${blocks} ld+json blocks, ${postsSeen} posts, ${skipped} redirect/noindex pages skipped`,
+  );
+
+  // A run that inspected nothing is a broken check, not a passing one. Same
+  // guard verify-og-images.mjs carries: without it, a path or regex change
+  // turns this into a no-op that prints success forever.
+  if (pages > 0 && blocks === 0) {
+    errors.push(
+      `found ${pages} pages but no ld+json blocks at all. Either the head partial stopped emitting them or LD_BLOCK no longer matches Hugo's output.`,
+    );
+  }
+  if (pages > 0 && !homeSeen) {
+    errors.push(
+      `never saw ${PUBLISH_DIR}/index.html, so the homepage was not checked.`,
+    );
+  }
+  if (pages > 0 && postsSeen === 0) {
+    errors.push(
+      `matched no post pages against ${POST_PATH}. If the content layout changed, this check has been silently verifying nothing.`,
+    );
+  }
+
+  if (errors.length > 0) {
+    log(`ERROR: ${errors.length} problem(s):`);
+    for (const error of errors.slice(0, 25)) log(`  ${error}`);
+    if (errors.length > 25) log(`  ...and ${errors.length - 25} more`);
+    process.exit(1);
+  }
+
+  log("all structured data is valid and every @id resolves");
+}
+
+try {
+  await main();
+} catch (error) {
+  log(`ERROR: ${error.message}`);
+  process.exit(1);
+}

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -8,4 +8,5 @@ One file per topic. Add a new file when a new kind of decision comes up.
 - [ai-crawlers.md](ai-crawlers.md) — who `robots.txt` lets in, and why that includes AI training crawlers
 - [page-metadata.md](page-metadata.md) — meta description, Open Graph, and Twitter card tags
 - [og-images.md](og-images.md) — generating the social card image each page shares with
+- [structured-data.md](structured-data.md) — the JSON-LD entity every page declares, and what to expect from it
 - [word-choice.md](word-choice.md) — preferred spellings and word forms

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -8,5 +8,5 @@ One file per topic. Add a new file when a new kind of decision comes up.
 - [ai-crawlers.md](ai-crawlers.md) — who `robots.txt` lets in, and why that includes AI training crawlers
 - [page-metadata.md](page-metadata.md) — meta description, Open Graph, and Twitter card tags
 - [og-images.md](og-images.md) — generating the social card image each page shares with
-- [structured-data.md](structured-data.md) — the JSON-LD entity every page declares, and what to expect from it
+- [structured-data.md](structured-data.md) — the JSON-LD entity the home page and blog posts declare, and what to expect from it
 - [word-choice.md](word-choice.md) — preferred spellings and word forms

--- a/decisions/structured-data.md
+++ b/decisions/structured-data.md
@@ -79,6 +79,21 @@ parsing schema.org.
 - **A standalone `Service` node on the consulting page** — folded into
   `Person.makesOffer` instead. One entity that offers something beats two nodes
   a search engine has to reconcile into one.
+- **A `price` on the `Offer`**, and the "fixed-price two-week sprint" wording
+  with it. `params.sprint` has both, and an earlier draft emitted them. The
+  problem is half-life: the `Person` node ships on every page the site emits,
+  next to `sameAs` and `knowsAbout`, which stay true for years. The shape and
+  price of the current consulting offer do not. Worse, a stale price would be
+  valid JSON with every required property present, so
+  `bin/verify-structured-data.mjs` could never flag it — the same silent
+  failure this whole design is built to avoid, at the semantic level instead of
+  the syntactic one. And there is nothing on the other side of the trade:
+  Google's Search Gallery documents no feature that reads an `Offer` on a
+  `Person`; price data earns a rich result only through `Product` and
+  `LocalBusiness`. `priceValidUntil` was the alternative, but it converts a
+  silent staleness problem into an expiry date nobody is reminded to bump. What
+  the `Offer` keeps is the durable claim: this person offers Elixir and Phoenix
+  consulting, and here is the page about it.
 - **`WebSite` with a `SearchAction`** — Google removed the sitelinks searchbox
   that consumed it.
 - **Deriving `knowsAbout` from tag counts** — cute, but the tag vocabulary
@@ -92,8 +107,8 @@ parsing schema.org.
   aimed at machines, and it should be as easy to revise as any other site copy.
 - `sameAs` reads from `data/profiles.yaml`, the same list the Follow page
   renders, so it can never claim an account the site does not visibly link.
-- The `Offer` price is derived from `params.sprint.price` by stripping
-  non-digits, so the human-facing string stays the one source.
+- The `Offer` carries no price, so `params.sprint` stays purely human-facing
+  copy and changing the sprint's price or shape needs no thought about schema.
 - `bin/verify-structured-data.mjs` runs on every build. Its most important
   check is that **every `@id` reference resolves within the same page**, which
   is the invariant this whole document describes and the one thing reading the

--- a/decisions/structured-data.md
+++ b/decisions/structured-data.md
@@ -98,5 +98,9 @@ parsing schema.org.
   check is that **every `@id` reference resolves within the same page**, which
   is the invariant this whole document describes and the one thing reading the
   template cannot confirm.
-- A post title over 110 characters now fails the build, because Google rejects
-  an Article headline past that. The longest today is 97.
+- **No headline length check**, deliberately. Google's Article docs used to cap
+  `headline` at 110 characters, and an early draft of the verifier failed the
+  build past that. Google dropped the cap in January 2023; the docs now say only
+  "consider using a concise title, as long titles may be truncated on some
+  devices." That is advice about taste, not a rule a build should enforce, so
+  there is nothing here to enforce it. Write the title the post needs.

--- a/decisions/structured-data.md
+++ b/decisions/structured-data.md
@@ -1,0 +1,102 @@
+# Declare one Person entity, and reference it from every page
+
+Every page that emits structured data emits a single
+`<script type="application/ld+json">` holding a `@graph` with two nodes: a
+`Person` describing Mike, and a node describing the page, which points at the
+Person by `@id` (`https://mikezornek.com/#mike`) rather than repeating him
+inline.
+
+Coverage is deliberately narrow:
+
+| Page            | Page node                                           |
+| --------------- | --------------------------------------------------- |
+| Home            | `ProfilePage`, whose `mainEntity` is the Person     |
+| Blog posts      | `BlogPosting`, authored and published by the Person |
+| Everything else | nothing                                             |
+
+**Why an entity rather than per-page facts:** the alternative is a
+self-contained `BlogPosting` on each post with the author's name as a plain
+string. That gives a search engine 400+ separate claims that someone named Mike
+Zornek wrote something, and leaves it to infer they are one person. The `@id`
+makes them 400+ pieces of evidence about one node. `sameAs` then bridges that
+node to the GitHub, LinkedIn, Mastodon, Bluesky, YouTube, and GoodReads
+accounts, which is what lets a search for the name resolve to a person rather
+than to a guess.
+
+**Why the Person node is repeated on every page** instead of declared once on
+the homepage and referenced from everywhere else: **Google parses each page
+independently.** A bare `@id` pointing at a node defined on another URL is
+unresolvable at the moment it is read. The `@graph` gets both properties at
+once — each page stands alone, and the shared `@id` ties them together for any
+consumer that does reconcile across pages. This looks like redundancy and is
+not; it is the reason the design works.
+
+**Why the homepage is the `ProfilePage`:** Google's rule is that "the primary
+focus of the page must be a single person or organization that is affiliated
+with the overall website," and its examples include "'About Me' pages on
+blogs." The homepage's `h1` is "Who is Mike Zornek?" followed by a first-person
+bio, so it qualifies without inventing a new page. This is also the only type
+used here with a documented search feature attached.
+
+**Why nothing on `/values/`, `/contact/`, `/now/`:** a `Person` node hung on
+those would assert they are about Mike the way the homepage is. They are not,
+and volume is not the goal.
+
+**Why the graph is built with `dict` and rendered by `jsonify`** rather than
+written as JSON text in the template: hand-assembled JSON is one apostrophe in
+a post title away from emitting a broken block, and a broken block fails
+silently.
+
+## Honest expectations
+
+Recorded so nobody later mistakes this for a growth lever.
+
+- **`BlogPosting` on a personal blog earns no visual rich result.** No badge,
+  no card, no stars. Google's Article documentation promises "better title
+  text, images, and date information" — improvements to an ordinary blue link.
+- **The entity/`sameAs` consolidation story is practitioner consensus, not a
+  Google citation.** Google documents `sameAs` as recommended; it does not
+  publish a page saying `sameAs` builds your knowledge-graph entity.
+- **The "AI answer engines read your schema" claim was investigated and
+  discarded.** The evidence for it is wall-to-wall SEO marketing with unsourced
+  figures. No AI vendor documents parsing JSON-LD.
+
+The case for doing it anyway: roughly thirty lines of template, a standard the
+search engines jointly founded, no ongoing maintenance, and no downside. Cheap
+permanent hygiene. Do not expect it to move Plausible.
+
+Verified 2026-07-30 against Google's structured data gallery: Article,
+Breadcrumb, and Profile Page are all currently supported with no deprecation
+notices. The types Google has killed (HowTo, FAQ, sitelinks searchbox) lost
+their **visual presentations** — Google stopped drawing the widgets, not
+parsing schema.org.
+
+## Considered and rejected
+
+- **`BreadcrumbList`** — URLs are `/posts/YYYY/M/slug/` and the intermediate
+  `/posts/YYYY/` levels are not real pages. The breadcrumb would be fictional
+  or trivial.
+- **A standalone `Service` node on the consulting page** — folded into
+  `Person.makesOffer` instead. One entity that offers something beats two nodes
+  a search engine has to reconcile into one.
+- **`WebSite` with a `SearchAction`** — Google removed the sitelinks searchbox
+  that consumed it.
+- **Deriving `knowsAbout` from tag counts** — cute, but the tag vocabulary
+  includes `personal`, `gaming`, and `reviews`. The list in
+  `params.identity` is written by hand and kept honest.
+
+## Consequences
+
+- Identity copy (`jobTitle`, `description`, `knowsAbout`, region) lives in
+  `params.identity` in `hugo.yaml`, not in the template. It is editorial text
+  aimed at machines, and it should be as easy to revise as any other site copy.
+- `sameAs` reads from `data/profiles.yaml`, the same list the Follow page
+  renders, so it can never claim an account the site does not visibly link.
+- The `Offer` price is derived from `params.sprint.price` by stripping
+  non-digits, so the human-facing string stays the one source.
+- `bin/verify-structured-data.mjs` runs on every build. Its most important
+  check is that **every `@id` reference resolves within the same page**, which
+  is the invariant this whole document describes and the one thing reading the
+  template cannot confirm.
+- A post title over 110 characters now fails the build, because Google rejects
+  an Article headline past that. The longest today is 97.

--- a/decisions/structured-data.md
+++ b/decisions/structured-data.md
@@ -1,4 +1,4 @@
-# Declare one Person entity, and reference it from every page
+# Declare one Person entity, and reference it from the pages that carry markup
 
 Every page that emits structured data emits a single
 `<script type="application/ld+json">` holding a `@graph` with two nodes: a
@@ -23,7 +23,7 @@ node to the GitHub, LinkedIn, Mastodon, Bluesky, YouTube, and GoodReads
 accounts, which is what lets a search for the name resolve to a person rather
 than to a guess.
 
-**Why the Person node is repeated on every page** instead of declared once on
+**Why the Person node is repeated on each of those pages** instead of declared once on
 the homepage and referenced from everywhere else: **Google parses each page
 independently.** A bare `@id` pointing at a node defined on another URL is
 unresolvable at the moment it is read. The `@graph` gets both properties at

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -28,6 +28,34 @@ params:
   sprint:
     headline: "Two weeks. One problem. $6,000."
     price: "$6,000"
+  # Facts about Mike-the-person, for the JSON-LD `Person` node that every page
+  # emits. See decisions/structured-data.md.
+  #
+  # This is editorial copy aimed at machines rather than readers, which is
+  # exactly why it lives here instead of being buried in a template: it is the
+  # answer to "who is this site about," and it should be as easy to revise as
+  # any other bit of site copy.
+  #
+  # Keep it true. `sameAs` comes from data/profiles.yaml, and `makesOffer` from
+  # the `sprint` block above, so neither is repeated here.
+  identity:
+    # Short enough to read as a title, not a pitch. The homepage says "I
+    # describe myself as both a developer and teacher"; this matches.
+    jobTitle: Developer and Teacher
+    description: Developer and teacher from the suburbs of Philadelphia, building digital products for over 25 years and working primarily in Elixir.
+    # Subjects this site actually has a body of writing about, roughly in
+    # proportion to the tag counts. Not an aspirational skills list.
+    knowsAbout:
+      - Elixir
+      - Phoenix Framework
+      - Software Craft
+      - Software Consulting
+      - iOS Development
+    # Coarse on purpose. "Suburbs of Philadelphia" is what the homepage says,
+    # and a street address has no business in a public JSON blob.
+    addressRegion: PA
+    addressCountry: US
+    image: /images/zorn_square_256.webp
   # Series listed newest-first (personal logging). Others default to oldest-first
   # so reading-order series (e.g. tutorials) read top-to-bottom.
   seriesNewestFirst:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -28,8 +28,9 @@ params:
   sprint:
     headline: "Two weeks. One problem. $6,000."
     price: "$6,000"
-  # Facts about Mike-the-person, for the JSON-LD `Person` node that every page
-  # emits. See decisions/structured-data.md.
+  # Facts about Mike-the-person, for the JSON-LD `Person` node emitted on the
+  # home page and on blog posts. No other page type carries structured data.
+  # See decisions/structured-data.md.
   #
   # This is editorial copy aimed at machines rather than readers, which is
   # exactly why it lives here instead of being buried in a template: it is the

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -37,21 +37,29 @@ params:
   # answer to "who is this site about," and it should be as easy to revise as
   # any other bit of site copy.
   #
-  # Keep it true. `sameAs` comes from data/profiles.yaml, and `makesOffer` from
-  # the `sprint` block above, so neither is repeated here.
+  # Keep it true. `sameAs` comes from data/profiles.yaml, so it is not repeated
+  # here. The `sprint` block above is not read by the JSON-LD at all: the
+  # `Offer` names the service and links the consulting page, but carries no
+  # price. See decisions/structured-data.md for why.
   identity:
     # Short enough to read as a title, not a pitch. The homepage says "I
     # describe myself as both a developer and teacher"; this matches.
     jobTitle: Developer and Teacher
     description: Developer and teacher from the suburbs of Philadelphia, building digital products for over 25 years and working primarily in Elixir.
-    # Subjects this site actually has a body of writing about, roughly in
-    # proportion to the tag counts. Not an aspirational skills list.
+    # What Mike wants to be known for now, not an inventory of the archive.
+    # These feed the entity association a search engine builds for him, so the
+    # test is "is this what he does today," not "has he written about it."
+    #
+    # iOS Development is deliberately absent for exactly that reason. The site
+    # has a real body of iOS writing and the /tags/ios/ archive stays up, but
+    # it is history rather than current practice, and listing it here would
+    # work against the Elixir positioning the consulting page is selling.
+    # Don't re-add it from the tag counts.
     knowsAbout:
       - Elixir
       - Phoenix Framework
       - Software Craft
       - Software Consulting
-      - iOS Development
     # Coarse on purpose. "Suburbs of Philadelphia" is what the homepage says,
     # and a street address has no business in a public JSON blob.
     addressRegion: PA

--- a/themes/reborn/layouts/partials/head.html
+++ b/themes/reborn/layouts/partials/head.html
@@ -36,6 +36,11 @@
 */}}
 {{ partial "og/social-image.html" . }}
 
+{{/* schema.org JSON-LD. Invisible to readers; it tells search engines what
+  this page is and who it is by. See decisions/structured-data.md.
+*/}}
+{{ partial "schema/structured-data.html" . }}
+
 {{ with .Site.Params.author.name }}
   <meta name="author" content="{{ . }}">
 {{ end }}

--- a/themes/reborn/layouts/partials/og/image-url.html
+++ b/themes/reborn/layouts/partials/og/image-url.html
@@ -1,0 +1,16 @@
+{{- /*
+  The absolute URL of the social image a page shares with: its own authored
+  image if it has one, otherwise its generated card.
+
+  Extracted so `og/social-image.html` (which emits the `og:image` and Twitter
+  tags) and `schema/structured-data.html` (which puts the same URL in the
+  page's JSON-LD) resolve it identically. Two copies of this two-branch rule
+  would eventually disagree, and the disagreement would be invisible.
+  */ -}}
+{{- $url := "" -}}
+{{- if partial "og/has-authored-image.html" . -}}
+  {{- $url = (index (partial "_funcs/get-page-images" .) 0).Permalink -}}
+{{- else -}}
+  {{- $url = partial "og/card-path" . | absURL -}}
+{{- end -}}
+{{- return $url -}}

--- a/themes/reborn/layouts/partials/og/social-image.html
+++ b/themes/reborn/layouts/partials/og/social-image.html
@@ -15,17 +15,14 @@
   contradicts, the "use the embedded templates" decision.
   */ -}}
 
-{{- /* `_funcs/get-page-images` returns image objects, not URL strings, so the
-  first one has to be dereferenced. Indexing is guarded because `index` on an
-  empty slice is an error, not an empty value. */ -}}
-{{- $images := partial "_funcs/get-page-images" . -}}
-{{- $image := "" -}}
-{{- if gt (len $images) 0 -}}
-  {{- $image = (index $images 0).Permalink -}}
-{{- end -}}
+{{- /* Resolving "authored image or generated card" now lives in
+  `og/image-url.html`, because the page's JSON-LD needs the same answer and two
+  copies of the rule would drift. The `og:image` tag is still emitted only for
+  pages without an authored image, since `_internal/opengraph.html` already
+  emitted one for the rest. */ -}}
+{{- $image := partial "og/image-url.html" . -}}
 
-{{- if not $image -}}
-  {{- $image = partial "og/card-path" . | absURL -}}
+{{- if not (partial "og/has-authored-image.html" .) -}}
   <meta property="og:image" content="{{ $image }}">
 {{- end }}
 

--- a/themes/reborn/layouts/partials/schema/structured-data.html
+++ b/themes/reborn/layouts/partials/schema/structured-data.html
@@ -41,22 +41,28 @@
   {{ $sameAs = $sameAs | append .url }}
 {{ end }}
 
-{{/* The consulting sprint, expressed as an Offer hanging off the Person rather
+{{/* The consulting work, expressed as an Offer hanging off the Person rather
   than as a standalone Service node on the consulting page. One entity that
   offers something beats two nodes a search engine has to reconcile.
 
-  The price is derived from `params.sprint.price` ("$6,000") by stripping
-  everything that is not a digit, because schema.org wants a bare number and
-  the human-facing string is the one that must not drift.
+  Deliberately no `price`, `priceCurrency`, or "two-week fixed-price sprint"
+  wording, even though `params.sprint` has all of it. This node ships on every
+  page the site emits and it sits next to `sameAs` and `knowsAbout`, which stay
+  true for years. The shape and price of the current offer do not. A stale
+  price here would be valid JSON with every required property present, so
+  verify-structured-data.mjs could never catch it — the same invisible failure
+  this whole file exists to prevent, one level up. Google documents no rich
+  result for an Offer on a Person either, so the number buys nothing to offset
+  the risk of it going quietly wrong.
+
+  What is left is the durable claim: this person offers Elixir and Phoenix
+  consulting, and here is the page about it. See decisions/structured-data.md.
 */}}
 {{ $offer := false }}
 {{ with site.GetPage "/elixir-consulting" }}
   {{ $offer = dict
     "@type" "Offer"
-    "name" "Fixed-price two-week Elixir consulting sprint"
     "url" .Permalink
-    "price" (replaceRE "[^0-9]" "" site.Params.sprint.price)
-    "priceCurrency" "USD"
     "itemOffered" (dict
     "@type" "Service"
     "name" "Elixir and Phoenix consulting"

--- a/themes/reborn/layouts/partials/schema/structured-data.html
+++ b/themes/reborn/layouts/partials/schema/structured-data.html
@@ -1,0 +1,135 @@
+{{/* The page's JSON-LD: a schema.org description of what this page is and who
+  it is by, written for machines rather than readers.
+
+  Structure, and the reasoning, are recorded in decisions/structured-data.md.
+  The short version:
+
+  Every page that emits anything emits ONE script tag holding a `@graph` with
+  two nodes — the `Person` (Mike) and a node for the page itself, which points
+  at the Person by `@id` rather than repeating him inline.
+
+  The Person node is repeated in full on every such page rather than declared
+  once on the homepage. That looks redundant and is not: Google parses each
+  page independently, so a bare `@id` reference to a node defined on some other
+  URL is unresolvable at the moment it matters. The `@graph` gives both
+  properties at once — self-contained per page, and tied together across pages
+  by the shared `@id`.
+
+  Pages covered:
+  home  -> ProfilePage, whose mainEntity is the Person
+  posts -> BlogPosting, authored and published by the Person
+  everything else -> nothing at all, deliberately. A `Person` node hung on
+  /values/ or /contact/ would assert that those pages are about him in the
+  same way the homepage is, which is not true and not useful.
+
+  The graph is built as Hugo maps and rendered with `jsonify`, not assembled as
+  a string. Hand-written JSON in a template is one unescaped quote in a post
+  title away from emitting a broken block, and a broken block fails silently.
+  `bin/verify-structured-data.mjs` checks the output on every build.
+*/}}
+
+{{ $personID := "#mike" | absURL }}
+{{ $identity := site.Params.identity }}
+
+{{/* `sameAs` is the property that tells a search engine the entity on this
+  site and the accounts on those other sites are one and the same. It reads
+  from data/profiles.yaml, the same list the Follow page renders, so it can
+  never claim an account the site does not visibly link.
+*/}}
+{{ $sameAs := slice }}
+{{ range hugo.Data.profiles.accounts }}
+  {{ $sameAs = $sameAs | append .url }}
+{{ end }}
+
+{{/* The consulting sprint, expressed as an Offer hanging off the Person rather
+  than as a standalone Service node on the consulting page. One entity that
+  offers something beats two nodes a search engine has to reconcile.
+
+  The price is derived from `params.sprint.price` ("$6,000") by stripping
+  everything that is not a digit, because schema.org wants a bare number and
+  the human-facing string is the one that must not drift.
+*/}}
+{{ $offer := false }}
+{{ with site.GetPage "/elixir-consulting" }}
+  {{ $offer = dict
+    "@type" "Offer"
+    "name" "Fixed-price two-week Elixir consulting sprint"
+    "url" .Permalink
+    "price" (replaceRE "[^0-9]" "" site.Params.sprint.price)
+    "priceCurrency" "USD"
+    "itemOffered" (dict
+    "@type" "Service"
+    "name" "Elixir and Phoenix consulting"
+    "provider" (dict "@id" $personID)
+    )
+  }}
+{{ end }}
+
+{{ $person := dict
+  "@type" "Person"
+  "@id" $personID
+  "name" site.Params.author.name
+  "url" site.Home.Permalink
+  "jobTitle" $identity.jobTitle
+  "description" $identity.description
+  "knowsAbout" $identity.knowsAbout
+  "image" ($identity.image | absURL)
+  "address" (dict
+  "@type" "PostalAddress"
+  "addressRegion" $identity.addressRegion
+  "addressCountry" $identity.addressCountry
+  )
+  "sameAs" $sameAs
+}}
+{{ if $offer }}
+  {{ $person = merge $person (dict "makesOffer" $offer) }}
+{{ end }}
+
+{{/* The page node. `$pageNode` staying false is the signal to emit nothing. */}}
+{{ $pageNode := false }}
+
+{{ if .IsHome }}
+  {{/* The homepage qualifies as a profile page under Google's rule that "the
+    primary focus of the page must be a single person or organization that is
+    affiliated with the overall website" — its h1 is "Who is Mike Zornek?"
+    followed by a first-person bio. It is the one page type here with a
+    documented search feature attached.
+  */}}
+  {{ $pageNode = dict
+    "@type" "ProfilePage"
+    "@id" (printf "%s#profilepage" .Permalink)
+    "url" .Permalink
+    "name" site.Title
+    "mainEntity" (dict "@id" $personID)
+  }}
+  {{ with .Lastmod }}
+    {{ $pageNode = merge $pageNode (dict "dateModified" (. | time.Format "2006-01-02T15:04:05Z07:00")) }}
+  {{ end }}
+{{ else if and .IsPage (in site.Params.mainSections .Type) }}
+  {{ $pageNode = dict
+    "@type" "BlogPosting"
+    "@id" (printf "%s#post" .Permalink)
+    "url" .Permalink
+    "mainEntityOfPage" .Permalink
+    "headline" .Title
+    "datePublished" (.Date | time.Format "2006-01-02T15:04:05Z07:00")
+    "dateModified" (.Lastmod | time.Format "2006-01-02T15:04:05Z07:00")
+    "image" (partial "og/image-url.html" .)
+    "author" (dict "@id" $personID)
+    "publisher" (dict "@id" $personID)
+    "inLanguage" "en-US"
+  }}
+  {{ with or .Description site.Params.description | plainify | htmlUnescape }}
+    {{ $pageNode = merge $pageNode (dict "description" .) }}
+  {{ end }}
+  {{ with .Params.tags }}
+    {{ $pageNode = merge $pageNode (dict "keywords" (delimit . ", ")) }}
+  {{ end }}
+{{ end }}
+
+{{ if $pageNode }}
+  {{ $graph := dict "@context" "https://schema.org" "@graph" (slice $pageNode $person) }}
+  <script type="application/ld+json">
+    {{ $graph | jsonify (dict "indent" "  ") | safeJS }}
+  </script>
+{{ end }}


### PR DESCRIPTION
Closes #170. Part of #144.

The site emitted **no structured data at all**. Search engines saw 400+ pages repeating a name in a byline and had to infer they described one person.

## The design in one paragraph

Every page that emits anything emits one `@graph` with two nodes: a `Person` carrying a stable `@id` (`https://mikezornek.com/#mike`), `sameAs`, and the consulting offer — plus a node for the page itself that points at the Person by `@id` instead of repeating him inline. `ProfilePage` on the homepage, `BlogPosting` on posts, **nothing anywhere else**.

**The one thing worth understanding before reviewing:** the Person node is repeated in full on all 448 pages rather than declared once on the homepage. That looks like a mistake and isn't. Google parses each page independently, so a bare `@id` pointing at a node defined on a different URL is unresolvable at the moment it's read. The `@graph` buys both properties at once — self-contained per page, tied together across pages by the shared id.

Full reasoning, alternatives rejected, and honest expectations: `decisions/structured-data.md`.

## Since you're reviewing this cold

**What it will and won't do.** `BlogPosting` on a personal blog earns no visual rich result — no badge, no card, no stars. Google's Article docs promise "better title text, images, and date information," i.e. a slightly better ordinary blue link. `ProfilePage` is the only type here with a documented SERP feature. The `sameAs` entity story is practitioner consensus, not a Google citation. And the "AI answer engines read your schema" claim turned out to be unsourced SEO marketing — I looked for a vendor doc and there isn't one.

So: **cheap permanent hygiene, not a traffic lever.** Don't expect Plausible to move. The decision record says this too, so nobody rediscovers the hype version later.

**Reviewing the validator is easier than reviewing the JSON-LD.** The rules are written as plain assertions in `bin/verify-structured-data.mjs`. Checking "does this assertion match what Google documents" is a much smaller job than eyeballing schema.

**The graph is built with `dict` and rendered by `jsonify`,** never assembled as JSON text. One apostrophe in a post title would otherwise emit a broken block, silently.

## Verification

Structured data fails exactly like the `og:image` paths in #159: invisibly. So it ships with a checker in `build.sh` next to `verify-og-images.mjs`. I fault-injected every check to prove it can fail:

| Injected fault | Result |
| --- | --- |
| `author.@id` → `#nobody` | `references @id "…#nobody" but no node on this page declares it` |
| Deleted `datePublished` | `BlogPosting is missing required "datePublished"` |
| Doubled comma in the JSON | `invalid JSON in ld+json block: Expected double-quoted property name…` |
| Deleted the whole block | `post declares no BlogPosting` |

It also carries the same no-op guards `verify-og-images.mjs` has — a run that inspects zero blocks, never sees the homepage, or matches zero posts fails rather than reporting success.

Clean run: `520 pages, 448 ld+json blocks, 447 posts` (447 posts + homepage = 448).

## The one refactor included

`og/image-url.html` is extracted so the JSON-LD `image` and the `og:image` tag resolve through one rule rather than two copies. **All 1040 `og:image`/`twitter:image` tags site-wide are byte-identical before and after** — including the tricky `professional-ios-projects-code-consistency-with-swiftlint` case, where Hugo auto-detects `book-cover.jpg` without any `images` front matter. The validator also asserts the two agree on every post from now on.

Full `hugo` → `og-images.mjs` → both verifiers run locally: clean, no deprecation warnings.

## Deliberately excluded

`BreadcrumbList` (the `/posts/YYYY/` levels aren't real pages, so it'd be fictional), a standalone `Service` node on the consulting page (folded into `Person.makesOffer` — one entity, not two to reconcile), and `WebSite`/`SearchAction` (Google removed the sitelinks searchbox).

**A headline length check**, which this branch briefly had and 7c8897c removed. It failed the build on any post title over 110 characters, citing a cap in Google's Article docs. Google deleted that cap in January 2023; the docs now say only "consider using a concise title, as long titles may be truncated on some devices." Enforcing it meant a long title would fail `build.sh` and block the Render deploy over a rule that no longer exists. Everything else in the verifier asserts something Google actually documents, which is what makes the file cheap to review, so this one didn't belong. `headline` is still required on `BlogPosting`; only the length cap is gone, and `decisions/structured-data.md` records why there's no check so it doesn't get re-added later.

**A `price` on the `Offer`**, removed in 9b94082 along with the "fixed-price two-week sprint" wording. `params.sprint` has both and an earlier draft emitted them, but it's a half-life mismatch: the `Person` node ships on all 448 pages next to `sameAs` and `knowsAbout`, which stay true for years, and the price and shape of the current sprint don't. A stale price would also be valid JSON with every required property present, so `verify-structured-data.mjs` could never flag it, which is this design's own failure mode turned on itself. Nothing is given up for it either: Google's Search Gallery documents no feature reading an `Offer` on a `Person`, and price data earns a rich result only via `Product` and `LocalBusiness`. `priceValidUntil` was the schema-correct alternative, but it trades silent staleness for an expiry date nobody is reminded to bump. The `Offer` keeps the durable claim: this person offers Elixir and Phoenix consulting, and here's the page. `params.sprint` is now purely human-facing copy and still renders on the consulting page and the availability banner unchanged.

## After deploy, not a merge blocker

Google's Rich Results Test needs a fetchable URL, so it can't run until this is live. **Merge on the code and the build check; do the manual pass on production afterward.**

Two URLs to paste in, once deployed:

- `https://mikezornek.com/` — expect `ProfilePage`, with `Person` as its `mainEntity`
- any post, e.g. the most recent — expect `BlogPosting`, author resolving to the same `#mike` id

**Not `/elixir-consulting/`.** An earlier draft of this section listed it, which was wrong: that page emits no JSON-LD. The consulting offer is `Person.makesOffer`, so it appears on the home and post pages rather than on the consulting page itself, and the Rich Results Test will correctly report "No items detected" for that URL. Nothing to check there.

## Editorial copy for you to tune

`params.identity` in `hugo.yaml` holds `jobTitle` ("Developer and Teacher"), a one-line `description`, and `knowsAbout`. I drew all of it from your existing homepage copy and tag distribution rather than inventing a pitch, but **it's your words about you** — that's why it's in config and not buried in a template.

`knowsAbout` originally included `iOS Development`, dropped in 1e1bb42. It's a positioning call, not an accuracy one: the iOS archive is real and stays up, but `knowsAbout` feeds the entity association a search engine builds for you, so it should say what you do now rather than inventory what you've written. The comment above the list used to say "derive from tag counts," which would have justified re-adding it on the next read; it now states the rule and says not to.

