### PR TITLE
Cap the RSS feeds at 50 items

### DIFF
--- a/decisions/README.md
+++ b/decisions/README.md
@@ -10,4 +10,5 @@ One file per topic. Add a new file when a new kind of decision comes up.
 - [og-images.md](og-images.md) — generating the social card image each page shares with
 - [structured-data.md](structured-data.md) — the JSON-LD entity the home page and blog posts declare, and what to expect from it
 - [llms-txt.md](llms-txt.md) — the generated `/llms.txt`, and why it is cheap optionality rather than a channel
+- [feeds.md](feeds.md) — why the RSS feeds are capped at 50 items and stay full-text
 - [word-choice.md](word-choice.md) — preferred spellings and word forms

--- a/decisions/feeds.md
+++ b/decisions/feeds.md
@@ -1,0 +1,82 @@
+# Cap the RSS feeds at 50 items, and keep them full-text
+
+Every RSS feed the site generates is capped at the 50 most recent items by
+`services.rss.limit` in `hugo.yaml`. Items still carry the complete post body.
+
+Before the cap, `/index.xml` was 1.96 MB of generated XML: 467 items, every one
+of them a full post. That is the entire archive in one document.
+
+Be precise about what that cost, because the raw file size overstates it twice
+over. Render serves the feed gzipped, so a full transfer was about 520 KB on
+the wire, not 1.96 MB. It also sends `ETag` and `Last-Modified`, and a
+conditional request returns `304` with a zero-byte body, so a reader polling an
+unchanged feed pays essentially nothing. Polling frequency was never the
+problem.
+
+What it did cost: the feed changes every time a post ships, and at that moment
+every subscriber downloads the whole document again to receive one new item.
+520 KB to deliver one post, times however many readers subscribe, on every
+publish. Clients that skip conditional requests pay it on every poll instead.
+Capping the item count is what shrinks that number, and it is the only lever
+here that does.
+
+The cap took the home feed from 1.96 MB to 486 KB, roughly 520 KB to 124 KB
+compressed, a 75% cut either way. Across the site's 30 generated feeds (home,
+sections, and every tag and series term) it is 6.5 MB to 3.3 MB raw, 1.7 MB to
+895 KB compressed.
+
+**Why 50 and not 10 or 20:** the number needs to be larger than the most posts
+a reader could plausibly miss between polls, or the feed silently drops posts
+for anyone whose reader was offline for a stretch. Recent years run a dozen to
+two dozen posts, so 50 is a couple of years of writing. Even 2022, the busiest
+year on record at 90 posts, would have needed a reader to go dark for roughly
+seven months before anything fell off the end.
+
+**Why full-text stays:** a full-text feed is a real courtesy. It lets people
+read in the tool they chose rather than being bounced to a browser, and it is
+the thing RSS is actually good at. The payload problem was the item _count_,
+not the item _size_, so bounding the count fixed it without taking anything
+away from the reading experience.
+
+## Considered and rejected
+
+- **Summaries instead of full text.** The larger payload cut, and the one that
+  costs readers the most. Rejected because it trades the feed's best property
+  for bytes that capping already recovers.
+- **A capped feed plus the full archive at a second URL.** Preserves
+  "subscribe and backfill," which approximately nobody does through RSS, in
+  exchange for a second output format, a second template, and a second thing to
+  keep working. The archive is already browsable, searchable, and in the
+  sitemap.
+- **Leave it alone.** The most defensible of the three, for the reasons in the
+  cost note above: compression and conditional GETs already absorb most of what
+  the raw file size suggests. Rejected because what they do not absorb is the
+  re-download every subscriber performs on every publish, and because the fix
+  is one config line that Hugo's template already honors, which is cheaper than
+  continuing to reason about whether it matters. Worth being explicit that
+  Render's outbound-bandwidth numbers were never pulled, so nobody knows
+  whether feeds were a real share of the 5 GB/month included on a Hobby
+  workspace. Measuring first was the plan in the issue; a one-line fix arrived
+  before the measurement did, and the measurement is now moot.
+
+## Consequences
+
+- `services.rss.limit` is global. It applies to the home feed, the section
+  feeds, and every tag and series term feed. That is the intent: the tag feeds
+  for the larger terms were hundreds of KB each for the same reason.
+- The template at `themes/reborn/layouts/_default/rss.xml` needed no change. It
+  is a 2020 fork of Hugo's embedded RSS template, kept because the embedded one
+  emits `.Summary` where this site wants `.Content`, and the limit check it
+  copied at the time still reads `.Site.Config.Services.RSS.Limit`. Switching
+  back to the embedded template is not an option here: it would silently turn
+  the feed into summaries, which is the choice rejected above. The fork has
+  drifted from upstream in other ways, tracked separately in #182.
+- The home feed draws from all regular pages, not just posts, so the project
+  and standalone pages are technically eligible for a slot. In practice none of
+  them carry `date` front matter, so Hugo gives them a zero date and they sort
+  to the very bottom: the highest-ranked one was item 448 of 467, roughly 400
+  places below the 50-item cutoff. The capped feed is 50 posts and nothing
+  else, and it no longer ships the `Mon, 01 Jan 0001` pubDates those pages were
+  emitting.
+- Anyone subscribing now gets the last 50 posts as their backfill instead of
+  the whole archive. That is the behavior nearly every blog feed already has.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -71,6 +71,12 @@ params:
     - Journals
 pagination:
   pagerSize: 20
+
+# Cap every generated RSS feed at the 50 most recent items. Items stay
+# full-text; only the count is bounded. See decisions/feeds.md.
+services:
+  rss:
+    limit: 50
 markup:
   goldmark:
     extensions:

--- a/playbook/search-consoles.md
+++ b/playbook/search-consoles.md
@@ -16,7 +16,7 @@ in an issue disappears when the issue closes; this does not.
 | ------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | Sitemap       | `https://mikezornek.com/sitemap.xml`                          | ~497 URLs, per-page `lastmod`. Hugo generates it.                                    |
 | Robots policy | `https://mikezornek.com/robots.txt`                           | Allows everything, advertises the sitemap. See `decisions/ai-crawlers.md`.           |
-| RSS           | `https://mikezornek.com/index.xml`                            | Full archive, full post bodies.                                                      |
+| RSS           | `https://mikezornek.com/index.xml`                            | 50 most recent items, full post bodies. See `decisions/feeds.md`.                    |
 | IndexNow key  | `https://mikezornek.com/509ce3a92525b2bfc2bdba120987afa2.txt` | Proves domain ownership to IndexNow. Contents must be exactly the key, nothing else. |
 
 **Last verified live: 2026-07-30.** `robots.txt` serves 200 as `text/plain`, its


### PR DESCRIPTION
Closes #173.

`/index.xml` was **1.96 MB** of generated XML: 467 items, every one carrying a full post body.

Worth stating the cost precisely, because the raw file size overstates it twice over. Render serves the feed gzipped (~520 KB on the wire) and sends `ETag`/`Last-Modified`, and a conditional request returns `304` with a zero-byte body — verified against the live site. Polling frequency was never the problem.

What it did cost: the feed changes every time a post ships, and at that moment every subscriber re-downloads the whole document to receive one new item. Capping the item count is the only lever that shrinks that.

## The change

One config key in `hugo.yaml`:

```yaml
services:
  rss:
    limit: 50
```

No template change was needed. `themes/reborn/layouts/_default/rss.xml` is a 2020 fork of Hugo's embedded RSS template, kept because the embedded one emits `.Summary` where this site wants `.Content`, and the limit check it copied at the time still reads `.Site.Config.Services.RSS.Limit`.

Of the four options in the issue, this is "cap the feed at N recent items." **Items stay full-text** — the payload problem was the item count, not the item size, and a full-text feed is a real courtesy worth keeping. `decisions/feeds.md` records the reasoning and why the other three were rejected.

## Measured

Built both configs and diffed the output:

| | before | after |
| --- | --- | --- |
| `/index.xml` raw | 1.96 MB, 467 items | 486 KB, 50 items |
| `/index.xml` compressed | ~520 KB | ~124 KB |
| all 30 feeds (home + sections + tag/series terms) | 6.5 MB raw / 1.7 MB gzip | 3.3 MB raw / 895 KB gzip |

Local `gzip -9` of the old feed gives 519,037 bytes against 519,694 measured on the wire, so the compressed figures are sound.

`index.json` (search index), `sitemap.xml`, and `llms.txt` are byte-identical: still 497 sitemap URLs and 467 search entries. Nothing about crawlability or on-site search changed, only what the feed re-serves. A full `diff -rq` of the two builds shows nothing outside the feeds changed.

## Why 50

Recent years run 12–22 posts, so 50 items is a few years of writing. Even 2022, the busiest year on record at 90 posts, would have needed a reader to go dark for roughly seven months before anything fell off the end.

## Notes

- **The limit is global**, wider than the issue's framing of `/index.xml` alone. It also caps the section, tag, and series feeds — the larger win, documented under Consequences in the decision record.
- **Render bandwidth was never measured.** The issue suggested measuring first. The one-line fix arrived before the measurement did; `decisions/feeds.md` says so explicitly rather than leaving a future reader to assume the number was pulled.
- `playbook/search-consoles.md` described the feed as "Full archive, full post bodies," which this makes false. Updated in the same commit, per that file's own standing instruction.
- Reviewing this turned up that the forked RSS template has drifted from upstream in ways unrelated to the full-text decision, including a wrong channel `<title>` on all 30 feeds. Deliberately left out of this PR and filed as #182.