### PR TITLE
Re-sync the RSS template with Hugo's embedded one

### DIFF
--- a/decisions/README.md
+++ b/decisions/README.md
@@ -10,5 +10,5 @@ One file per topic. Add a new file when a new kind of decision comes up.
 - [og-images.md](og-images.md) — generating the social card image each page shares with
 - [structured-data.md](structured-data.md) — the JSON-LD entity the home page and blog posts declare, and what to expect from it
 - [llms-txt.md](llms-txt.md) — the generated `/llms.txt`, and why it is cheap optionality rather than a channel
-- [feeds.md](feeds.md) — why the RSS feeds are capped at 50 items and stay full-text
+- [feeds.md](feeds.md) — why the RSS feeds are capped at 50 items, stay full-text, and how their forked template is kept in sync with Hugo's
 - [word-choice.md](word-choice.md) — preferred spellings and word forms

--- a/decisions/feeds.md
+++ b/decisions/feeds.md
@@ -103,8 +103,8 @@ What the re-sync actually changed in the output:
 - **`transform.XMLEscape` instead of `| html` on item content.** Decoded item
   bodies are byte-identical, verified across all 30 feeds with an XML parser.
   The difference is on the wire: `XMLEscape` writes newlines as `&#xA;`, which
-  grows the home feed from 486 KB to 495 KB raw, and about 0.3% compressed
-  whatever level the compressor runs at. Taking a payload increase in a doc
+  grows the home feed from 486 KB to 495 KB raw, and by about 0.3% compressed
+  at any compression level. Taking a payload increase in a doc
   that just argued for cutting payload needs a reason, and it is this:
   `XMLEscape` is XML-aware where `html` is not, and it strips control
   characters that are illegal in XML rather than emitting a feed no strict

--- a/decisions/feeds.md
+++ b/decisions/feeds.md
@@ -1,4 +1,4 @@
-# Cap the RSS feeds at 50 items, and keep them full-text
+# RSS feeds: 50 items, full text, and one forked template
 
 Every RSS feed the site generates is capped at the 50 most recent items by
 `services.rss.limit` in `hugo.yaml`. Items still carry the complete post body.
@@ -64,13 +64,13 @@ away from the reading experience.
 - `services.rss.limit` is global. It applies to the home feed, the section
   feeds, and every tag and series term feed. That is the intent: the tag feeds
   for the larger terms were hundreds of KB each for the same reason.
-- The template at `themes/reborn/layouts/_default/rss.xml` needed no change. It
-  is a 2020 fork of Hugo's embedded RSS template, kept because the embedded one
-  emits `.Summary` where this site wants `.Content`, and the limit check it
-  copied at the time still reads `.Site.Config.Services.RSS.Limit`. Switching
-  back to the embedded template is not an option here: it would silently turn
-  the feed into summaries, which is the choice rejected above. The fork has
-  drifted from upstream in other ways, tracked separately in #182.
+- The template at `themes/reborn/layouts/_default/rss.xml` needed no change for
+  the cap. It is a fork of Hugo's embedded RSS template, kept because the
+  embedded one emits `.Summary` where this site wants `.Content`, and the limit
+  check it copied still reads `.Site.Config.Services.RSS.Limit`. Switching back
+  to the embedded template is not an option here: it would silently turn the
+  feed into summaries, which is the choice rejected above. See the next section
+  for how the fork is maintained.
 - The home feed draws from all regular pages, not just posts, so the project
   and standalone pages are technically eligible for a slot. In practice none of
   them carry `date` front matter, so Hugo gives them a zero date and they sort
@@ -80,3 +80,45 @@ away from the reading experience.
   emitting.
 - Anyone subscribing now gets the last 50 posts as their backfill instead of
   the whole archive. That is the behavior nearly every blog feed already has.
+
+## Keeping the template fork a one-line diff
+
+The fork was copied out of a 2020-era Hugo and then never re-synced, so by the
+time anyone looked at it again (#182) it differed from upstream in eight
+places, only one of which was the full-text change it exists for. It has been
+re-copied from `tpl/tplimpl/embedded/templates/rss.xml` at v0.161.1, the
+version in use, with the one intended edit re-applied on top. The file says so
+in a comment at the top, so the next person does not have to diff it against
+upstream to find out what is deliberate.
+
+Re-copy the same way when Hugo's embedded template changes. Hand-patching the
+fork is what produced the drift.
+
+What the re-sync actually changed in the output:
+
+- **Channel `<title>` on the 29 non-home feeds.** This was the real bug. Every
+  feed announced itself as `Mike Zornek`, so a reader subscribed to more than
+  one term feed saw identical names in the sidebar. `/tags/elixir/index.xml` is
+  now `elixir on Mike Zornek`, and so on. The home feed is unchanged.
+- **`transform.XMLEscape` instead of `| html` on item content.** Decoded item
+  bodies are byte-identical, verified across all 30 feeds with an XML parser.
+  The difference is on the wire: `XMLEscape` writes newlines as `&#xA;`, which
+  grows the home feed from 486 KB to 495 KB raw, and about 0.3% compressed
+  whatever level the compressor runs at. Taking a payload increase in a doc
+  that just argued for cutting payload needs a reason, and it is this:
+  `XMLEscape` is XML-aware where `html` is not, and it strips control
+  characters that are illegal in XML rather than emitting a feed no strict
+  parser will accept. The archive happens not to contain any today. One pasted
+  character is all it would take.
+- **`<generator>` dropped its `-- gohugo.io` suffix**, matching upstream.
+- **Whitespace.** Upstream trims differently around `<atom:link>` and each
+  `<item>`, so every feed's bytes shift a little even where the content does
+  not. Nothing parses differently.
+
+Also taken from upstream, with no effect on this site's output: `.PublishDate`
+instead of `.Date` for `<pubDate>` (identical here, since no post sets
+`publishDate` separately), `lastBuildDate` from the newest `Lastmod` in the
+feed rather than the page's own date, `<language>` emitted unconditionally
+rather than guarded by `with` (`locale` is set in `hugo.yaml`, so the guard
+never fired), and a `reflect.IsMap` guard around the author lookup so a scalar
+`params.author` would not error.

--- a/themes/reborn/layouts/_default/rss.xml
+++ b/themes/reborn/layouts/_default/rss.xml
@@ -1,39 +1,73 @@
-{{- $pctx := . -}}
-{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
-{{- $pages := slice -}}
-{{- if or $.IsHome $.IsSection -}}
-{{- $pages = $pctx.RegularPages -}}
-{{- else -}}
-{{- $pages = $pctx.Pages -}}
-{{- end -}}
-{{- $limit := .Site.Config.Services.RSS.Limit -}}
-{{- if ge $limit 1 -}}
-{{- $pages = $pages | first $limit -}}
-{{- end -}}
+{{- /*
+  A fork of Hugo's embedded RSS template
+  (tpl/tplimpl/embedded/templates/rss.xml), last reconciled against v0.161.1.
+
+  It exists for exactly one reason: the embedded template puts `.Summary` in
+  each item's `<description>`, and this site's feeds are deliberately
+  full-text, so the item `<description>` below emits `.Content` instead. See
+  decisions/feeds.md for why full-text stays.
+
+  Everything else here is upstream verbatim. When Hugo's embedded template
+  changes, re-copy it and re-apply that one line rather than hand-patching, so
+  the fork stays a one-line diff instead of drifting again.
+*/ -}}
+{{- $authorEmail := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .email }}
+      {{- $authorEmail = . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- $authorName := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .name }}
+      {{- $authorName = . }}
+    {{- end }}
+  {{- else }}
+    {{- $authorName  = . }}
+  {{- end }}
+{{- end }}
+
+{{- $pctx := . }}
+{{- if .IsHome }}{{ $pctx = .Site }}{{ end }}
+{{- $pages := slice }}
+{{- if or $.IsHome $.IsSection }}
+{{- $pages = $pctx.RegularPages }}
+{{- else }}
+{{- $pages = $pctx.Pages }}
+{{- end }}
+{{- $limit := .Site.Config.Services.RSS.Limit }}
+{{- if ge $limit 1 }}
+{{- $pages = $pages | first $limit }}
+{{- end }}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>{{ .Site.Title }}</title>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
-    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Params.author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>
-    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
-    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
-    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
-    {{ with .OutputFormats.Get "RSS" }}
-	{{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
-    {{ end }}
-    {{ range $pages }}
+    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo</generator>
+    <language>{{ site.Language.Locale }}</language>{{ with $authorEmail }}
+    <managingEditor>{{.}}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
+    <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with .Site.Copyright }}
+    <copyright>{{ . }}</copyright>{{ end }}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ (index $pages.ByLastmod.Reverse 0).Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
-      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with $.Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
+      <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Content | html }}</description>
+      {{- /* The one forked line. Upstream emits `.Summary`; see the note above. */}}
+      <description>{{ .Content | transform.XMLEscape | safeHTML }}</description>
     </item>
-    {{ end }}
+    {{- end }}
   </channel>
 </rss>


### PR DESCRIPTION
Closes #182.

`themes/reborn/layouts/_default/rss.xml` was copied out of a 2020-era Hugo and never re-synced, so it had drifted from upstream in eight places, only one of which was the full-text change the fork exists for.

Re-copied from `tpl/tplimpl/embedded/templates/rss.xml` at v0.161.1, the version in use, with that one edit re-applied on top: the item `<description>` emits `.Content` instead of `.Summary`. Diffing the new file against upstream (ignoring the two added comments) returns exactly that one line.

The file now carries a header comment saying what it is, why it exists, and what version it was last reconciled against, plus the rule that keeps it from drifting again: re-copy upstream and re-apply the one line, never hand-patch.

## What changes in the output

Built the site before and after and compared all 30 generated feeds.

- **Channel `<title>` on the 29 non-home feeds.** This was the actual bug. Every feed announced itself as `Mike Zornek`, so a reader subscribed to more than one term feed saw identical names in the sidebar. `/tags/elixir/index.xml` is now `elixir on Mike Zornek`. The home feed is unchanged.
- **`transform.XMLEscape` instead of `| html` on item content.** Decoded item bodies are byte-identical, verified across all 30 feeds with an XML parser. The difference is only on the wire: `XMLEscape` writes newlines as `&#xA;`, costing about 0.3% compressed (486 KB → 495 KB raw on the home feed). Worth taking because it is XML-aware where `html` is not, and it strips control characters that are illegal in XML rather than emitting a feed no strict parser will accept.
- **`<generator>`** loses its `-- gohugo.io` suffix.

The `.PublishDate`, `lastBuildDate`, `<language>` and `reflect.IsMap` rows were also taken from upstream and produce identical output on this site.

## Verification

- Only the feeds changed. No HTML page differs.
- All 30 feeds parse. Item `guid` / `description` / `pubDate` are byte-identical after XML decoding.
- At channel level, only `generator` (30 feeds) and `title` (29 feeds) changed. No element added or dropped, and every `lastBuildDate` is unchanged.

## Docs

`decisions/feeds.md` had a stale bullet saying this drift was "tracked separately in #182". That is now a section recording the re-sync, what it changed, and the no-hand-patching rule. The file's title and its `decisions/README.md` index line are widened, since it now covers two decisions rather than just the 50-item cap.
