### PR TITLE
Fail the build when a Start Here entry's path doesn't resolve

### DIFF
--- a/docs/adr/0001-curated-list-via-data-file.md
+++ b/docs/adr/0001-curated-list-via-data-file.md
@@ -16,4 +16,20 @@ numbers and leaves nowhere clean for the editorial note).
 
 **Consequence:** entries reference posts by logical path, so moving or renaming a
 post's bundle means updating this file. That trade is acceptable: we move posts
-almost never, and the template skips any entry whose path no longer resolves.
+almost never. An entry whose path no longer resolves fails the build: both
+templates that render this list (`partials/start-here-list.html` and
+`_default/index.llmstxt.txt`) call `errorf` rather than skip the entry.
+
+**Also considered and rejected (#176):** skipping an unresolvable entry instead,
+on the theory that a renamed bundle should degrade the homepage rather than
+block every deploy. That was the original behavior here, and reversing it is
+deliberate, not an oversight to re-raise. The list is short and hand-picked, so
+losing one entry is proportionally large and completely invisible: no warning,
+no build noise, just a shorter list nobody notices for months. Same class of
+silent failure that `bin/verify-og-images.mjs` and `bin/verify-structured-data.mjs`
+exist to catch. The skip traded a loud, immediate, self-inflicted problem (a
+deploy that stops on the same commit where the post moved, naming the exact path
+to fix) for a quiet permanent one (a broken curated list in production), which
+is the wrong direction. Note the one sharp edge: an entry pointing at a draft
+resolves under `hugo server -D` but not in a production build, so that mistake
+surfaces at deploy time rather than locally.

--- a/themes/reborn/layouts/_default/index.llmstxt.txt
+++ b/themes/reborn/layouts/_default/index.llmstxt.txt
@@ -10,6 +10,9 @@
   format asks for, written for a different reason. A hand-maintained copy would
   go stale the first time a post was published; this cannot.
 
+  An entry whose path no longer resolves FAILS THE BUILD, matching
+  partials/start-here-list.html so both renderings of the same data agree.
+
   See decisions/llms-txt.md for the honest assessment of whether anything reads
   this file. Short version: no major AI vendor documents consuming it. It is
   here because it costs one template, not because it is a proven channel.
@@ -31,7 +34,7 @@ Hand-picked, hand-ranked. If you only read a few things, read these.
 {{ range $entry := . -}}
 {{- with (site.GetPage $entry.path) -}}
 - [{{ .Title }}]({{ .Permalink }}){{ with $entry.note }}: {{ . | plainify }}{{ end }}
-{{ end -}}
+{{ else }}{{ errorf "index.llmstxt.txt: data/start-here.yaml entry path %q resolves to no page. Fix the path or drop the entry (see docs/adr/0001-curated-list-via-data-file.md)." $entry.path }}{{ end -}}
 {{- end }}
 {{ end -}}
 

--- a/themes/reborn/layouts/partials/start-here-list.html
+++ b/themes/reborn/layouts/partials/start-here-list.html
@@ -3,9 +3,12 @@
   <h2> heading, a lead line, and the entries divided by hairlines, with no
   background or border of its own.
 
-  Resolves each entry's logical path to a Page and skips any that no longer
-  resolve. Renders nothing at all when the list is empty (empty-state guard) so
-  no bare heading or panel ever appears.
+  Resolves each entry's logical path to a Page. THE BUILD FAILS if a path no
+  longer resolves, rather than quietly rendering a shorter list: the list is
+  short and hand-picked, so losing one entry is both proportionally large and
+  invisible. See docs/adr/0001-curated-list-via-data-file.md. Renders nothing at
+  all when the list is empty (empty-state guard) so no bare heading or panel
+  ever appears.
 
   Takes no context — the heading, lead, and heading levels are fixed here since
   every caller renders the same list the same way.
@@ -19,6 +22,8 @@
     {{- range $entry := . }}
       {{- with (site.GetPage $entry.path) }}
         {{ partial "start-here-card.html" (dict "page" . "note" $entry.note "headingLevel" "h3") }}
+      {{- else }}
+        {{- errorf "start-here-list.html: data/start-here.yaml entry path %q resolves to no page. Fix the path or drop the entry (see docs/adr/0001-curated-list-via-data-file.md)." $entry.path }}
       {{- end }}
     {{- end }}
   </div>


### PR DESCRIPTION
Closes #176.

`data/start-here.yaml` references posts by logical path, and both templates that render it wrapped the lookup in `{{ with (site.GetPage $entry.path) }}`, so an entry whose path went stale was silently dropped. No warning, no failure, just a shorter list. Same class of quiet failure as the broken `og:image` paths in #159, and worse here: the list is short and hand-picked, so losing one entry is proportionally large and nobody sees it.

Both templates now `errorf` instead, which is already the established pattern in `shortcodes/figure.html`.

## What's in here

- `partials/start-here-list.html` — `{{ else }}{{ errorf … }}` on the `site.GetPage` lookup
- `_default/index.llmstxt.txt` — the same, so both renderings of the same data behave identically
- `docs/adr/0001-curated-list-via-data-file.md` — Consequence rewritten to say the build fails, plus an "Also considered and rejected (#176)" paragraph

The ADR had recorded the skip as an accepted consequence, so the issue's counter-argument (the skip is a safety valve: a renamed bundle degrades the homepage instead of blocking every deploy) gets recorded as weighed and rejected rather than silently reversed. It also notes the one sharp edge: an entry pointing at a **draft** resolves under `hugo server -D` but not in a production build, so that mistake surfaces at deploy time rather than locally.

## Verification

Broke a path in `data/start-here.yaml` and ran the pinned Hugo 0.161.1:

```
ERROR start-here-list.html: data/start-here.yaml entry path "/posts/2022/11/my-standup-format-MOVED" resolves to no page. Fix the path or drop the entry (see docs/adr/0001-curated-list-via-data-file.md).
ERROR index.llmstxt.txt: data/start-here.yaml entry path "/posts/2022/11/my-standup-format-MOVED" resolves to no page. Fix the path or drop the entry (see docs/adr/0001-curated-list-via-data-file.md).
ERROR error building site: logged 2 error(s)
```

`hugo` exits 1, and `bin/build.sh` sets `-o errexit`, so the deploy stops there and Render blocks it.

With the paths intact, a full build exits 0 and `diff -r` against a build from `main` is byte-identical, so the `{{ else }}` insertion caused no whitespace regression in `llms.txt`.

## Noted, not fixed

Neither is a regression from this PR; both are pre-existing and can be their own issue if they're worth it.

- The resolve-or-fail call is now duplicated in two templates, with the "both must agree" invariant living in a comment rather than in code. A returning partial would dedupe it, at the cost of indirection for two callers with quite different shapes.
- An empty or missing `posts:` key is still silent: delete `data/start-here.yaml` and the whole section vanishes from the homepage and `llms.txt` without a peep. That's the documented empty-state guard working as designed, but it's a larger silent failure than the one this PR closes.