### PR TITLE
Mark /search/ noindex and drop it from the sitemap (#175)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,6 +22,13 @@ A short, author-written sentence attached to a Start Here entry that tells the
 reader why the post is worth their time or where it fits. Distinct from a post's
 own `description` front matter, which is the post's general summary.
 
+**Utility page**:
+A page whose purpose is to perform an action rather than to say something, and
+which therefore has nothing to offer an index. `/search/` and `/random/` are the
+two. The test is whether the page has content of its own: a term page listing
+two posts is thin, but it is not a utility page, because what it lists is real.
+_Avoid_: system page, meta page, non-content page.
+
 **Social card**:
 The landscape image a page shares with when its link is posted somewhere. It is
 the reader's first impression of a link, seen before the page itself, and it

--- a/bin/verify-og-images.mjs
+++ b/bin/verify-og-images.mjs
@@ -45,9 +45,16 @@ const IMAGE_TAG =
 // rather than pages, so having no social image is correct, not a defect.
 const ALIAS_STUB = /<meta\s+http-equiv="refresh"/i;
 
-// A page that tells crawlers not to index it is not a page anyone shares, and
-// some do not load the theme's head partial at all. `/random/` is the example:
-// a standalone layout that bounces the visitor straight to a random post.
+// Some noindex pages do not load the theme's head partial at all and so emit no
+// social tags. `/random/` is the example: a standalone layout that bounces the
+// visitor straight to a random post. Having no card is correct for those.
+//
+// This deliberately excuses only a *missing* `og:image`, never a present one.
+// The rule used to skip any noindex page outright, using "noindex" as a proxy
+// for "emits no social tags". `/search/` broke that proxy: it is noindex, and it
+// renders through head.html, so it advertises a real card that the manifest
+// really generates. Under the old rule that card silently left coverage, which
+// is exactly the broken-share failure this script exists to catch.
 const NOINDEX = /<meta\s+name="robots"\s+content="[^"]*noindex/i;
 
 function log(message) {
@@ -97,16 +104,23 @@ async function main() {
   for await (const file of htmlFiles(PUBLISH_DIR)) {
     const html = await readFile(file, "utf8");
 
-    if (ALIAS_STUB.test(html) || NOINDEX.test(html)) {
+    if (ALIAS_STUB.test(html)) {
+      skipped += 1;
+      continue;
+    }
+
+    const matches = [...html.matchAll(IMAGE_TAG)];
+    const hasOgImage = matches.some(([, tag]) => tag === "og:image");
+
+    if (!hasOgImage && NOINDEX.test(html)) {
       skipped += 1;
       continue;
     }
     pages += 1;
 
-    const matches = [...html.matchAll(IMAGE_TAG)];
     const page = "/" + relative(PUBLISH_DIR, file);
 
-    if (!matches.some(([, tag]) => tag === "og:image")) {
+    if (!hasOgImage) {
       missingImage.push(page);
       continue;
     }

--- a/content/random.md
+++ b/content/random.md
@@ -2,11 +2,6 @@
 title: Random Post
 description: A random post pulled from the archive, re-rolled every time you land here.
 layout: random
-# A utility page, same as /search/. This flag is the declaration; unlike
-# /search/ it is not what emits the meta tag, because `layout: random` is a
-# standalone template that never loads head.html and hardcodes its own
-# `noindex,nofollow`. Setting it here anyway is what keeps /llms.txt from
-# needing a hardcoded list of page names. See decisions/indexing.md.
 noindex: true
 build:
   list: never

--- a/content/random.md
+++ b/content/random.md
@@ -2,6 +2,12 @@
 title: Random Post
 description: A random post pulled from the archive, re-rolled every time you land here.
 layout: random
+# A utility page, same as /search/. This flag is the declaration; unlike
+# /search/ it is not what emits the meta tag, because `layout: random` is a
+# standalone template that never loads head.html and hardcodes its own
+# `noindex,nofollow`. Setting it here anyway is what keeps /llms.txt from
+# needing a hardcoded list of page names. See decisions/indexing.md.
+noindex: true
 build:
   list: never
   render: always

--- a/content/search/_index.md
+++ b/content/search/_index.md
@@ -1,7 +1,13 @@
 ---
 title: "Search"
 description: Search every post on this site by title, tag, and content.
+# A utility page: it runs a search rather than saying anything, so it has
+# nothing to offer an index. `noindex` is read by head.html; `sitemap.disable`
+# keeps the page out of sitemap.xml while it still renders and stays in every
+# page collection. The old `priority: 0.1` is gone because Google documents
+# that it ignores <priority> entirely. See decisions/indexing.md.
+noindex: true
 sitemap:
-  priority: 0.1
+  disable: true
 layout: "search"
 ---

--- a/content/search/_index.md
+++ b/content/search/_index.md
@@ -1,11 +1,6 @@
 ---
 title: "Search"
 description: Search every post on this site by title, tag, and content.
-# A utility page: it runs a search rather than saying anything, so it has
-# nothing to offer an index. `noindex` is read by head.html; `sitemap.disable`
-# keeps the page out of sitemap.xml while it still renders and stays in every
-# page collection. The old `priority: 0.1` is gone because Google documents
-# that it ignores <priority> entirely. See decisions/indexing.md.
 noindex: true
 sitemap:
   disable: true

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -6,6 +6,7 @@ don't have to be rediscovered later.
 One file per topic. Add a new file when a new kind of decision comes up.
 
 - [ai-crawlers.md](ai-crawlers.md) — who `robots.txt` lets in, and why that includes AI training crawlers
+- [indexing.md](indexing.md) — which pages are deliberately kept out of search indexes, and why that is a separate question from crawl policy
 - [page-metadata.md](page-metadata.md) — meta description, Open Graph, and Twitter card tags
 - [og-images.md](og-images.md) — generating the social card image each page shares with
 - [structured-data.md](structured-data.md) — the JSON-LD entity the home page and blog posts declare, and what to expect from it

--- a/decisions/ai-crawlers.md
+++ b/decisions/ai-crawlers.md
@@ -43,3 +43,15 @@ in full rather than citing them.
 **Consequence:** `robots.txt` stays short. New crawlers need no action — they
 are allowed by default, which is the intended posture. If we ever do want to
 block one, this file should be updated in the same commit as the `Disallow`.
+
+---
+
+## Crawling is not indexing
+
+This file is about who may **fetch** pages. What may be **indexed** is a
+separate decision, recorded in [indexing.md](indexing.md), and the two are not
+interchangeable. A `Disallow` here stops a page being fetched, which means any
+`noindex` tag on it is never read, and search engines can still index a blocked
+URL on the strength of inbound links. So `robots.txt` is the wrong tool for
+keeping a page out of an index, and the pages that carry `noindex` today
+(`/search/` and `/random/`) are deliberately left crawlable.

--- a/decisions/indexing.md
+++ b/decisions/indexing.md
@@ -1,0 +1,185 @@
+# Indexing
+
+Which pages are deliberately kept out of search indexes, and why. This is a
+different question from crawl policy: `robots.txt` says who may _fetch_ what
+(see [ai-crawlers.md](ai-crawlers.md)), and a `noindex` meta tag says what may
+be _indexed_. Neither substitutes for the other, and blocking a page in
+`robots.txt` actively prevents its `noindex` from ever being read.
+
+The evidence behind everything below, quoted and sourced, is in
+[docs/research-search-page-indexing.md](../docs/research-search-page-indexing.md).
+Sources were read on 2026-07-31.
+
+---
+
+## `/search/` is `noindex` and out of the sitemap
+
+**Preferred:** `noindex: true` and `sitemap: {disable: true}` in
+`content/search/_index.md`.
+
+**Rejected:** leaving it indexable and sitemapped, which is what it was.
+
+**Why:** `/search/` is a utility page. It exists to run a search, not to say
+anything, so it has nothing to offer an index. With no query it returns HTTP 200
+and the text "Please enter a word or phrase above," which is precisely Google's
+own documented example of a soft 404 ("an empty internal search result page"),
+and Google says soft 404s "are excluded from Search."
+
+Note what that means: **the page was never going to be indexed either way.** The
+choice here is not indexed versus not indexed. It is who decides, and what the
+record looks like afterwards. Left alone, Google renders the page, classifies it
+a soft 404, and drops it, leaving a soft-404 row in Search Console that is
+indistinguishable from a genuinely broken page. With the tag, the same outcome
+arrives deterministically and shows up as "URL marked 'noindex'", which reads as
+a decision instead of a defect. Google's JavaScript SEO doc adds that it "may
+skip rendering and JavaScript execution" on a `noindex` page, so the explicit
+version is also the cheaper one to serve.
+
+That is the whole case. It is a tidiness argument, honestly made. Nobody was
+being harmed by the old state.
+
+---
+
+## The rule everyone remembers is not current guidance
+
+**Preferred:** argue this from documentation that is live today.
+
+**Rejected:** "Google says don't index internal search results."
+
+**Why:** That sentence is folklore with a real but dated origin. It traces to a
+Matt Cutts blog post of **March 10, 2007** and a line added to the old Webmaster
+Guidelines at the time. That guidelines page,
+`support.google.com/webmasters/answer/35769`, now returns 404, and no equivalent
+survives in Search Essentials, the spam policies, the faceted navigation guide,
+or the crawl budget guide. All four were checked.
+
+No evidence was found that Google penalizes, demotes, or spam-flags a small site
+for one indexable internal search page. The absence is a finding, not a gap in
+the research, and it is why the soft-404 argument above carries the decision
+rather than a spam argument.
+
+Related things worth not repeating:
+
+- **Google documents that it ignores `<priority>` in sitemaps.** The page used
+  to set `sitemap: {priority: 0.1}`, which bought nothing. It is gone.
+- **"Submitted URL marked 'noindex'" no longer exists in Search Console.** The
+  current Page Indexing report has no Errors section at all and files this under
+  _Not indexed_, alongside the note that "it's fine for a URL not to be indexed
+  for the right reasons." So a `noindex` URL sitting in a sitemap is untidy, not
+  an error. The sitemap removal rests on Google's positive instruction to
+  "include the URLs in your sitemap that you want to see in Google's search
+  results," and not on avoiding a penalty that isn't there.
+- **The crawl budget guide scopes itself out for a site this size** and advises
+  against using `noindex` for crawl efficiency anyway. Crawl budget is not a
+  reason for anything on a 497-URL site.
+
+---
+
+## Plain `noindex`, never `noindex,nofollow`
+
+**Preferred:** `<meta name="robots" content="noindex">`.
+
+**Rejected:** `noindex,nofollow`, which is what `/random/` uses.
+
+**Why:** `nofollow` is documented as "do not follow the links on this page," and
+on `/search/` that would include the site's own header and footer navigation.
+There is nothing to gain in exchange. The result links are built client-side
+after a query runs, and Google may skip rendering `noindex` pages entirely, so
+those links were never a crawl path that needed suppressing.
+
+The claim that a long-lived `noindex` eventually behaves like `nofollow` is
+**not documented first-party anywhere.** It traces to a John Mueller hangout
+remark reported through SEO blogs. It is not a basis for anything here.
+
+---
+
+## The `?q=` URLs are covered, and only by the meta tag
+
+`themes/reborn/assets/js/search.js` reads a `q` parameter and runs the search on
+load, so `/search/?q=elixir` is a real, shareable, crawlable URL, and the space
+is unbounded. Two things follow.
+
+The meta tag covers all of it, because those URLs are the same document. The
+sitemap change covers none of it, because those URLs were never in the sitemap.
+Anyone revisiting this should not read "removed from the sitemap" as having done
+anything at all about the parameterized space.
+
+Separately, `head.html` emits `<link rel="canonical" href="{{ .Permalink }}">`,
+and `.Permalink` on `/search/?q=elixir` is the bare `/search/`. So the parameter
+space already consolidated to one URL before any of this, which is a large part
+of why the old state was defensible.
+
+---
+
+## `/random/` says the same thing a different way
+
+`/random/` is the other utility page, and it expresses the identical intent
+through completely different machinery: a hardcoded `noindex,nofollow` in its
+own standalone layout, and `build: {list: never}` rather than
+`sitemap: {disable: true}`.
+
+This is left alone on purpose. `layout: random` is a full standalone template
+that never loads `head.html`, so the `.Params.noindex` flag could not emit its
+tag even if we wanted it to. `/random/` does carry `noindex: true` in front
+matter regardless, as a declaration rather than a mechanism, so that anything
+reasoning about utility pages has one flag to read.
+
+Worth knowing if `/random/` is ever revisited: `build: {list: never}` is a much
+bigger hammer than it needs. It removes the page from _every_ page collection,
+where `sitemap: {disable: true}` would remove only the sitemap entry. The
+difference has not mattered yet.
+
+---
+
+## Hugo mechanics, verified against v0.161.1
+
+`sitemap: {disable: true}` in front matter is the surgical tool: the page still
+renders to disk and still appears in `site.Pages`, and only its `<url>` entry
+disappears. It landed in Hugo **v0.125.0 (2024-04-16)**, confirmed against the
+`config.SitemapConfig` struct and the embedded sitemap template at tag
+`v0.161.1`. This repo does not override that template, so it applies directly.
+
+The alternatives were tested in a throwaway build rather than assumed:
+
+| Front matter               | In `sitemap.xml`? | Rendered to disk? |
+| -------------------------- | ----------------- | ----------------- |
+| _(none)_                   | yes               | yes               |
+| `sitemap: {disable: true}` | no                | yes               |
+| `build: {list: never}`     | no                | yes               |
+| `build: {render: never}`   | no                | no                |
+| `build: {render: link}`    | **yes**           | **no**            |
+
+`build: {render: link}` is a trap: the page is never written to disk but stays
+in the sitemap, because it keeps a `Permalink`. Do not reach for it.
+
+---
+
+## Consequence for the social-card verifier
+
+`bin/verify-og-images.mjs` used to skip any page carrying a `noindex` tag,
+using that tag as a proxy for "emits no social tags at all." The proxy held only
+while `/random/` was the only `noindex` page on the site. `/search/` renders
+through `head.html` and therefore advertises a real card, so the old rule would
+have quietly dropped it from coverage the moment this change shipped.
+
+The skip now tests the condition it always meant: a `noindex` page is excused
+for having _no_ `og:image`, never for having a broken one. Written up in
+[og-images.md](og-images.md).
+
+---
+
+## What this does not decide
+
+Thin tag and series term pages, which is [#174](https://github.com/zorn/mikezornek.com/issues/174).
+
+Issue #175 guessed the two were the same shape of question. They are not, and
+the vocabulary is the clearest way to see it. `/search/` is a **utility page**:
+it performs an action and has no content of its own. A tag page with two posts
+is an **index page with thin content**, which is a different problem argued from
+different documents. Nothing about the soft-404 reasoning above transfers to it,
+because a term page listing two real posts is not an empty page.
+
+What does transfer is the mechanism. `.Params.noindex` exists now, and
+`head.html` can grow an `or` condition if #174 decides some term pages should
+carry the tag. Term pages are generated and have no front matter file to write
+into, so that work will need a condition in the template regardless.

--- a/decisions/og-images.md
+++ b/decisions/og-images.md
@@ -408,10 +408,20 @@ bundle name that a hand search had missed and the verifier found immediately.
 
 Two kinds of page are skipped, both deliberately. **Alias redirect stubs**: Hugo
 writes a bare refresh page for each `aliases` entry, around 190 of them for the
-pre-2020 URL scheme, with none of the theme's head partial. **Pages marked
-`noindex`**: `/random/` has a standalone layout that never loads `head.html` and
-bounces the visitor onward, so it emits no social tags and needs no card. A page
-telling crawlers not to index it is not a page anyone shares.
+pre-2020 URL scheme, with none of the theme's head partial. **Pages that emit no
+`og:image` at all and are marked `noindex`**: `/random/` has a standalone layout
+that never loads `head.html` and bounces the visitor onward, so it emits no
+social tags and needs no card.
+
+**Narrowed by [indexing.md](indexing.md):** that second skip was originally
+written as "any page marked `noindex`", using the tag as a proxy for "emits no
+social tags". The proxy held only while `/random/` was the sole `noindex` page.
+`/search/` is now `noindex` too, and it renders through `head.html`, so it
+advertises a real card that the manifest really generates — under the old rule
+that card silently dropped out of coverage. The skip now tests the condition it
+always meant: a `noindex` page is excused for _having no_ `og:image`, never for
+having a broken one. Any future `noindex` page that goes through `head.html`
+stays verified by default.
 
 ---
 

--- a/docs/research-search-page-indexing.md
+++ b/docs/research-search-page-indexing.md
@@ -1,0 +1,550 @@
+# Research: should `/search/` be `noindex`?
+
+Primary-source research input for [issue #175](https://github.com/zorn/mikezornek.com/issues/175).
+This file is **evidence, not a decision.** The decision (if one is made) belongs in `decisions/`.
+
+**Sources accessed 2026-07-31.** Everything below is either quoted from a first-party
+source (Google Search Central, Google Search Console Help, sitemaps.org, Hugo docs,
+Hugo source, Bing) or explicitly flagged as weak, dated, or absent. No SEO blogs are
+cited as authority.
+
+---
+
+## What this settles
+
+1. **Google has no current documented policy against indexing a site's own internal search
+   page.** The rule people remember ("use robots.txt to block search results pages") comes
+   from a **March 10, 2007** Matt Cutts blog post and a line that was added to the old
+   Webmaster Guidelines back then. That guidelines page (`support.google.com/webmasters/answer/35769`)
+   now returns **404**, and the line does not appear anywhere in today's Search Essentials
+   or spam policies. Treat it as folklore with a real but dated first-party origin.
+2. **The one live, on-point Google doc is about soft 404s, not spam.** Google lists
+   "an empty internal search result page" as an example of a soft 404. `/search/` with no
+   query currently renders exactly that ("Please enter a word or phrase above."). This is the
+   strongest documented argument for keeping `/search/` out of the index — and it argues just
+   as well for taking it out of the sitemap.
+3. **"Submitted URL marked 'noindex'" is not a thing in Search Console anymore.** The current
+   Page Indexing report has no "Errors" section and no status by that name. It says
+   "URL marked 'noindex'" under _Not indexed_, and states outright that non-indexed URLs can
+   be fine. So a noindexed URL sitting in the sitemap is **not** a documented error. It is
+   still contrary to Google's own sitemap guidance ("Include the URLs in your sitemap that
+   you want to see in Google's search results"), which is a tidiness argument, not an error.
+4. **`noindex,nofollow` is documented to stop link following; plain `noindex` is not.**
+   The "long-lived noindex eventually behaves like nofollow" claim is **not documented
+   anywhere first-party** — it traces to a John Mueller hangout remark, not to Google docs.
+5. **Hugo mechanism is settled and exact for v0.161.1:** front matter `sitemap: {disable: true}`
+   exists, was introduced in **Hugo v0.125.0 (released 2024-04-16)**, and drops the page from
+   `sitemap.xml` while still rendering it and keeping it in all page collections. Verified
+   against Hugo's source at tag `v0.161.1` and by an empirical local build. This repo uses
+   Hugo's embedded sitemap template (no override), so the mechanism applies as documented.
+6. **`?q=` is real.** `search.js` reads a `q` query parameter and auto-runs the search, so
+   `/search/?q=anything` is a linkable, crawlable, indexable URL that renders results. Any
+   decision should cover the parameterized form, not just the bare `/search/`.
+
+---
+
+## Local check: does `/search/` read a query from the URL?
+
+**Yes.** File: `/Users/zorn/ProjectRepos/mikezornek/themes/reborn/assets/js/search.js`
+
+- Param name: **`q`**
+- Read at line 32: `var searchQuery = param("q");`
+- `param()` (lines 227–229) does a naive `location.search` split:
+  ```js
+  function param(name) {
+    return decodeURIComponent(
+      (location.search.split(name + "=")[1] || "").split("&")[0],
+    ).replace(/\+/g, " ");
+  }
+  ```
+- Lines 31–39: if `q` is present, the input is prefilled and `executeSearch(searchQuery, false)`
+  runs immediately on load. If `q` is absent, `#search-results` is set to
+  `<p class="search-results-empty">Please enter a word or phrase above.</p>`.
+
+Consequences for this decision:
+
+- `https://mikezornek.com/search/?q=elixir` is a fully functional, shareable, crawlable URL.
+  Nothing in the site links to one today (checked: `search-form.html` uses a GET form, so a
+  submitted search _does_ produce `?q=` in the address bar and can be copied/shared/linked
+  from off-site). The URL space is effectively unbounded.
+- The bare `/search/` — the URL that _is_ in `sitemap.xml` — renders **no results at all**,
+  matching Google's own soft-404 example (see Q1 below).
+- Results are rendered client-side from `/index.json` after loading Fuse.js and Mark.js from
+  `cdnjs.cloudflare.com` (see `themes/reborn/layouts/_default/search.html`). Rendering is
+  required before any result link exists in the DOM.
+- Lines 109–111 build outbound links to `duckduckgo.com` and `google.com` scoped searches,
+  but only after a query runs, so a crawler hitting bare `/search/` never sees them.
+
+---
+
+## Q1 — What does Google actually document today about indexing internal site-search result pages?
+
+### Current documentation: essentially nothing prohibitive
+
+- **Spam policies** — no mention of internal search result pages. Checked in full; the closest
+  concept is "Doorway abuse," described as "Generating pages to funnel visitors into the actual
+  usable or relevant portion of a site," which does not describe a site search page.
+  https://developers.google.com/search/docs/essentials/spam-policies
+- **Search Essentials** (top-level: Technical requirements / Spam policies / Key best practices) —
+  no mention of search results pages or auto-generated pages.
+  https://developers.google.com/search/docs/essentials
+- **Faceted navigation guide** — recommends `robots.txt` for _faceted_ URLs
+  ("Use robots.txt to disallow crawling of faceted navigation URLs. Oftentimes there's no good
+  reason to allow crawling of filtered items…") but says **nothing** about internal site search.
+  https://developers.google.com/search/docs/crawling-indexing/crawling-managing-faceted-navigation
+
+### The one live, on-point doc: soft 404s
+
+Google's crawling-errors documentation lists, as an example of a soft 404:
+
+> "An empty internal search result page"
+
+https://developers.google.com/search/docs/crawling-indexing/troubleshoot-crawling-errors
+
+Related definition, same doc family: a soft 404 is "a URL that returns a page telling the user
+that the page does not exist and also a `200 (success)` status code," and such pages "are
+excluded from Search."
+
+**This is the only current first-party Google statement that actually bears on this site's
+`/search/` page**, and it fits precisely: bare `/search/` returns 200 with no results and the
+text "Please enter a word or phrase above."
+
+Note what it does _not_ say: it does not distinguish a parameterized results URL from a
+results-rendering page, and it does not say to noindex anything. It says Google may classify
+the empty variant as a soft 404 and drop it.
+
+### Crawl budget guide — explicitly not applicable to this site
+
+> "This guide describes how to optimize Google's crawling of very large and frequently updated
+> sites. If your site doesn't have a large number of pages that change rapidly, or if your pages
+> seem to be crawled the same day that they are published, you don't need to read this guide."
+
+Who it's for: "Large sites (1 million+ unique pages)…", "Medium or larger sites (10,000+ unique
+pages) with very rapidly changing content (daily)…". mikezornek.com is ~497 URLs. **The crawl
+budget argument does not apply here by Google's own scoping.**
+
+That said, its advice is worth recording because it cuts _against_ using `noindex` for
+crawl-efficiency reasons:
+
+> "Don't use `noindex`, as Google will still request, but then drop the page when it sees a
+> `noindex` meta tag or header in the HTTP response, wasting crawling time."
+
+https://developers.google.com/crawling/docs/crawl-budget
+(canonical URL; `…/search/docs/crawling-indexing/large-site-managing-crawl-budget` redirects there).
+Last updated 2026-07-22 UTC.
+
+### The legacy origin, dated
+
+The "don't let your search results get indexed" guidance is real but **dated 2007** and comes
+from a Google employee's **personal blog**, not documentation:
+
+- Matt Cutts, "Search results in search results," **published March 10, 2007**, quoting
+  Vanessa Fox (then of Google):
+
+  > "Typically, web search results don't add value to users, and since our core goal is to
+  > provide the best search results possible, we generally exclude search results from our web
+  > search index."
+
+  and the guideline line that was added to the Webmaster Guidelines as a result:
+
+  > "Use robots.txt to prevent crawling of search results pages or other auto-generated pages
+  > that don't add much value for users coming from search engines."
+
+  https://www.mattcutts.com/blog/search-results-in-search-results/
+
+- **That guideline line is gone.** The old Webmaster Guidelines page
+  `https://support.google.com/webmasters/answer/35769` returns **HTTP 404** (verified
+  2026-07-31). The guidelines were replaced by Search Essentials in October 2022
+  (https://developers.google.com/search/blog/2022/10/search-essentials), and the current
+  Search Essentials and spam policies contain no equivalent line.
+
+- I could **not** find any "Search results in search results" post on
+  `developers.google.com/search/blog` — `…/blog/2007/09/search-results-in-search-results`
+  returns 404 and no such post surfaces in a site-scoped search. If a Google-hosted version
+  ever existed, it did not survive the migration to Search Central.
+
+**Weak-evidence flag:** anyone citing "Google says don't index search results" today is citing
+a 19-year-old blog post from an employee's personal site plus a guidelines line that Google has
+since deleted. That is not the same as current documented policy. It is also not evidence that
+Google _reversed_ the position — Google simply stopped saying anything.
+
+---
+
+## Q2 — A `noindex` URL listed in an XML sitemap
+
+### Is it an ERROR in Search Console? No — not as documented today.
+
+The current **Page Indexing report** help doc:
+
+- Has **no section literally titled "Errors."** Statuses are grouped as _Indexed_,
+  _Not indexed_, and warnings ("Improve page appearance").
+- Has **no status named "Submitted URL marked 'noindex'."** That name is legacy Index Coverage
+  report vocabulary and does not appear in the current doc.
+- The status that does exist is **"URL marked 'noindex'"**, listed under _Not indexed_:
+  > "When Google tried to index the page it encountered a 'noindex' directive and therefore did
+  > not index it."
+- And explicitly:
+  > "It's fine for a URL not to be indexed for the right reasons—for example, an expected
+  > robots.txt rule on your site, a noindex tag on the page, a duplicate URL, or a 404 for a
+  > page that you've removed and have no replacement for."
+  > "Non-indexed URLs can be fine. Read and understand the specific reason for each non-indexed
+  > URL to confirm that the page shouldn't be indexed."
+
+https://support.google.com/webmasters/answer/7440203
+
+The report does offer a **sitemap filter** ("All known pages," "All submitted pages,"
+"Unsubmitted pages only," specific sitemaps), so a noindexed sitemap URL _is_ attributable to
+the sitemap — but it is surfaced as a reason, not an error.
+
+**Sitemaps report** help doc: lists parsing errors ("URLs not accessible," "URL not allowed,"
+"Invalid URL") and **contains no error or warning about submitting noindex URLs.**
+https://support.google.com/webmasters/answer/7451001
+
+**Verdict:** the widely repeated "Search Console will throw an error if you sitemap a noindex
+URL" is out of date. It was true of the older Index Coverage report's _Error_ bucket; the
+current documentation neither uses that name nor classifies it as an error. **Evidence
+flagged as: previously true, no longer documented.**
+
+### What Google says a sitemap should contain
+
+> "Include the URLs in your sitemap that you want to see in Google's search results. Google
+> generally shows the canonical URLs in its search results, which you can influence with sitemaps."
+
+> "Google ignores `<priority>` and `<changefreq>` values."
+
+https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap
+(Last updated 2026-07-08 UTC.)
+
+Directly relevant: `content/search/_index.md` sets `sitemap: {priority: 0.1}`. **That value is
+documented as ignored by Google.** It buys nothing today.
+
+### sitemaps.org
+
+> "The Sitemap protocol enables you to provide details about your pages to search engines."
+
+> `<priority>` — "The priority of this URL relative to other URLs on your site. Valid values
+> range from 0.0 to 1.0."
+
+> `<changefreq>` — "How frequently the page is likely to change. This value provides general
+> information to search engines and may not correlate exactly to how often they crawl the page."
+> … "Please note that the value of this tag is considered a _hint_ and not a command."
+
+https://www.sitemaps.org/protocol.html
+
+sitemaps.org imposes no rule about noindex URLs. The only constraint quoted is host scoping:
+"All URLs in a Sitemap must be from a single host."
+
+**Net:** listing a noindexed URL is not an error under either spec. It is simply
+self-contradictory — the sitemap says "I want this in search results," the meta tag says the
+opposite. If `/search/` gets `noindex`, removing it from the sitemap is the consistent move,
+and the priority 0.1 line can go with it since Google ignores it anyway.
+
+---
+
+## Q3 — `noindex` vs `noindex,nofollow`
+
+Google's robots meta tag spec, verbatim (https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag,
+last updated 2026-03-24 UTC):
+
+> **`noindex`** — "Do not show this page, media, or resource in search results. If you don't
+> specify this rule, the page, media, or resource may be indexed and shown in search results."
+
+> **`nofollow`** — "Do not follow the links on this page. If you don't specify this rule, Google
+> may use the links on the page to discover those linked pages."
+
+> **`none`** — "Equivalent to `noindex, nofollow`."
+
+Also:
+
+> "Keep in mind that these settings can be read and followed only if crawlers are allowed to
+> access the pages that include these settings."
+
+> "robots `meta` tags and `X-Robots-Tag` HTTP headers are discovered when a URL is crawled. If a
+> page is disallowed from crawling through the robots.txt file, then any information about
+> indexing or serving rules will not be found and will therefore be ignored."
+
+And from the noindex how-to (https://developers.google.com/search/docs/crawling-indexing/block-indexing,
+last updated 2025-12-10 UTC):
+
+> "`noindex` is a rule set with either a `<meta>` tag or HTTP response header and is used to
+> prevent indexing content by search engines that support the `noindex` rule, such as Google.
+> When Googlebot crawls that page and extracts the tag or header, Google will drop that page
+> entirely from Google Search results, regardless of whether other sites link to it."
+
+> "Specifying the `noindex` rule in the robots.txt file is not supported by Google."
+
+> "You can also combine the `noindex` rule with other rules that control indexing. For example,
+> you can join a `nofollow` hint with a `noindex` rule: `<meta name="robots" content="noindex, nofollow" />`."
+
+### Documented consequence of `nofollow` on the page's own links
+
+Exactly what the spec says: Google will not follow the links on the page, so it will not use
+them to discover the linked pages. For `/search/` that means the nav/footer/header links and
+any client-rendered result links would not be used as discovery paths. **Practically irrelevant
+here** — every post is already in `sitemap.xml` and reachable from `/posts/`, tag pages, and the
+home page. But it is a real, documented difference, and it's why `/random/`'s existing
+`noindex,nofollow` is more aggressive than it needs to be.
+
+### The "long-lived noindex eventually behaves like nofollow" claim
+
+**Not documented anywhere first-party.** I checked:
+
+- The robots meta tag spec — no statement about noindex pages' links changing behavior over time.
+- The block-indexing (`noindex`) doc — same, nothing.
+
+The claim traces to **John Mueller in a Google Webmaster Hangout** (commonly cited as 2017, and
+restated in later years including 2019), reported only through third-party write-ups
+(seroundtable, WebmasterWorld, various SEO blogs). There is no Google documentation page,
+no Search Central blog post, and no help-center article stating it.
+
+**Report it as: a dated verbal statement by a Google employee, not documented policy.**
+It should not carry weight in the decision. If the concern it addresses (link discovery) mattered,
+it would already be handled by the sitemap.
+
+---
+
+## Q4 — Bing
+
+### What I could retrieve
+
+Bing's Webmaster Guidelines are served from a JavaScript single-page app
+(`https://www.bing.com/webmasters/help/webmaster-guidelines-30fba23a`). The article body is
+**not present in the static HTML** and could not be retrieved as text by either fetch or curl
+(HTTP 200, 125 KB, body is app scaffolding and localization strings only). Both attempts
+returned only the page title "Bing Webmaster Tools - Help Documentation."
+
+**No first-party Bing statement about internal site search result pages was found.** Searching
+Bing's blog and help index surfaced nothing on the topic. Record this as **absent evidence**,
+not as "Bing has no opinion."
+
+### What is retrievable, and is genuinely first-party
+
+Bing's own webmaster app strings (extracted from `bing.com/webmasters/help`, 2026-07-31) confirm
+Bing honors the tag and how it reports it:
+
+- On `noindex` support:
+
+  > "You have a `<meta name="robots" content="NOINDEX">` on your pages: If your pages contain
+  > `<meta name="robots" content="NOINDEX">` in the page's source code we will not add them to
+  > the index."
+  > (Appears in Bing's "Why is my site not in the index?" and "Not crawling" help text.)
+
+- On removing a URL:
+
+  > "To remove a URL from your site from the Bing index. There are three ways: Method 1: Remove
+  > the Page from Your Site and Return a 404. Method 2: Add a NOINDEX meta tag to the page.
+  > Method 3: Remove the URL using the Block URLs tool."
+  > https://www.bing.com/webmasters/help/how-can-i-remove-a-url-or-page-from-the-bing-index-37c07477
+
+- **On noindex URLs in a submitted sitemap** — Bing Webmaster Tools has a _Sitemap Index Coverage_
+  category literally titled **"No-index tag"** / **"URLs with NOINDEX tag"**, described as:
+
+  > "These URLs have 'noindex' tag and are not indexed by Bingbot."
+
+  It is presented as a coverage breakdown category with sample URLs, **not as an error**.
+  This is the closest Bing analogue to the Search Console question in Q2, and the answer is
+  the same: informational, not an error.
+
+- Bing's dedicated reference page for robots meta support (retrievable URL, body not
+  extractable): https://www.bing.com/webmasters/help/robots-meta-tags-and-attributes-that-bing-supports-5198d240
+
+**Weak-evidence flag:** the Bing quotes above are first-party (they come from Bing's own
+product), but they are UI help strings, not the Webmaster Guidelines document. I was unable to
+read the Guidelines document itself.
+
+---
+
+## Q5 — Hugo mechanism (exact for v0.161.1)
+
+Installed locally: `hugo v0.161.1+extended+withdeploy darwin/arm64`.
+
+### The definitive mechanism: Hugo's embedded sitemap template
+
+At tag `v0.161.1`, `tpl/tplimpl/embedded/templates/sitemap.xml` begins:
+
+```gotemplate
+{{ range where .Pages "Sitemap.Disable" "ne" true }}
+  {{- if .Permalink -}}
+<url>
+  <loc>{{ .Permalink }}</loc>...
+```
+
+Source: https://github.com/gohugoio/hugo/blob/v0.161.1/tpl/tplimpl/embedded/templates/sitemap.xml
+
+Two filters, and they are the whole story:
+
+1. the page must be in `.Pages` (the page collection), and
+2. `Sitemap.Disable` must not be `true`, and
+3. `.Permalink` must be non-empty.
+
+**This repo has no `layouts/sitemap.xml` override** (checked: no sitemap template anywhere
+outside `public/`), so the embedded template above is what runs. Any of the three levers works.
+
+### `sitemap: {disable: true}` — CONFIRMED, exists, and is the right tool
+
+The config struct at `v0.161.1`, `config/commonConfig.go`:
+
+```go
+// SitemapConfig configures the sitemap to be generated.
+type SitemapConfig struct {
+	// The page change frequency.
+	ChangeFreq string
+	// The priority of the page.
+	Priority float64
+	// The sitemap filename.
+	Filename string
+	// Whether to disable page inclusion.
+	Disable bool
+}
+```
+
+Docs (https://gohugo.io/configuration/sitemap/):
+
+> **`disable`** — "Whether to disable page inclusion. Default is `false`. Set to `true` in front
+> matter to exclude the page."
+
+> "These are the default sitemap configuration values. They apply to all pages unless overridden
+> in front matter."
+
+Also documented at https://gohugo.io/methods/page/sitemap/ and
+https://gohugo.io/content-management/front-matter/.
+
+**Version introduced: Hugo v0.125.0, released 2024-04-16.**
+
+- Commit `6738a3e7` "tpl/tplimpl: Optionally exclude content from sitemap," authored 2024-04-01,
+  PR gohugoio/hugo#12329, commit message: "Define global inclusion/exclusion in site
+  configuration, and override via front matter. For example, to exclude a page from the sitemap:
+  `[sitemap]` / `disable = true # default is false`. Closes #653. Closes #12282."
+- Verified by ancestry: the commit is **not** an ancestor of `v0.124.1` and **is** an ancestor of
+  `v0.125.0` (GitHub compare API returns `ahead` vs `v0.124.1`, `behind` vs `v0.125.0`).
+- Named in the v0.125.0 release notes: "tpl/tplimpl: Optionally exclude content from sitemap [6738a3e]"
+  https://github.com/gohugoio/hugo/releases/tag/v0.125.0
+
+v0.161.1 is far past that. **Available.**
+
+### `build: {list: ...}` and `build: {render: ...}` — exact semantics
+
+Verbatim from https://gohugo.io/content-management/build-options/:
+
+> **`list`** — "When to include the page within page collections. Specify one of:
+> `always`: Include the page in _all_ page collections. For example, `site.RegularPages`,
+> `.Pages`, etc. This is the default value.
+> `local`: Include the page in _local_ page collections. For example, `.RegularPages`, `.Pages`, etc.
+> `never`: Do not include the page in _any_ page collection."
+
+> **`render`** — "When to render the page. Specify one of:
+> `always`: Always render the page to disk. This is the default value.
+> `link`: Do not render the page to disk, but assign `Permalink` and `RelPermalink` values.
+> `never`: Never render the page to disk, and exclude it from all page collections."
+
+> **`publishResources`** — "Determines whether to publish the associated page resources.
+> `true`: Always publish resources. This is the default value.
+> `false`: Only publish a resource when invoking its `Permalink`, `RelPermalink`, or `Publish`
+> method within a template."
+
+**The Hugo build-options doc never mentions `sitemap.xml`.** The sitemap consequences are
+implied by the embedded template, not stated. So I verified them empirically.
+
+### Empirical verification (local, Hugo v0.161.1)
+
+Minimal throwaway site, one page per option, `hugo` build, then read `public/sitemap.xml` and `ls public/`:
+
+| Front matter                              | In `sitemap.xml`? | Rendered to disk? |
+| ----------------------------------------- | ----------------- | ----------------- |
+| _(none — baseline)_                       | **yes**           | yes               |
+| `sitemap: {disable: true}`                | **no**            | **yes**           |
+| `sitemap: {disable: true, priority: 0.1}` | **no**            | **yes**           |
+| `build: {list: never}`                    | **no**            | **yes**           |
+| `build: {render: never}`                  | **no**            | **no**            |
+| `build: {render: link}`                   | **yes** ⚠️        | **no** ⚠️         |
+
+Notes that matter for implementation:
+
+- **`sitemap: {disable: true}` is the surgical option.** The page still renders to
+  `/search/index.html`, still appears in `site.Pages` / `site.RegularPages` (so it can still be
+  linked from nav, still counted, still available to any template), and only the `<url>` entry
+  disappears. This is exactly what `/search/` needs.
+- **`build: {list: never}` also removes it from the sitemap** (because the sitemap ranges over
+  `.Pages`) and still renders the page. This is what `/random/` uses today, and it explains why
+  `/random/` is absent from `sitemap.xml`. But it is a bigger hammer: the page vanishes from
+  _every_ page collection, which would also drop it from the JSON search index at `/index.json`
+  and from anything else iterating `site.Pages`.
+- **`build: {render: link}` is a trap.** The page is _not_ written to disk but _is_ still listed
+  in `sitemap.xml`, because it retains a `Permalink`. Never use it here.
+- **`build: {render: never}` removes it from the sitemap by removing the page entirely** — no
+  HTML output at all. Not viable for a page you want people to use.
+
+### Complete list of first-party-documented ways to keep a page out of `sitemap.xml`
+
+1. **`sitemap: {disable: true}` in front matter** (or globally in `hugo.yaml` under `sitemap:`,
+   overridden per page). Hugo ≥ v0.125.0. https://gohugo.io/configuration/sitemap/
+2. **`build: {list: never}` in front matter** — excludes from all page collections, and the
+   embedded sitemap template ranges over a page collection.
+   https://gohugo.io/content-management/build-options/
+3. **`build: {render: never}` in front matter** — page is never written and is excluded from all
+   page collections. Same doc.
+4. **Override the sitemap template** at `layouts/sitemap.xml` (or in the theme) and filter
+   however you like. https://gohugo.io/templates/sitemap/
+5. **`disableKinds: [sitemap]` in site config** — nuclear; disables sitemap generation entirely.
+   https://gohugo.io/configuration/all/
+
+Options 1 and 2 are the only two that keep the page live for humans. Option 1 is the one that
+does nothing else.
+
+### Note on the existing `sitemap: {priority: 0.1}`
+
+Hugo will happily emit both `disable: true` and `priority: 0.1`; `disable` wins and no `<url>`
+is emitted (verified above). But since **Google documents that it ignores `<priority>` entirely**
+(Q2), the `priority: 0.1` line in `content/search/_index.md` is dead weight either way.
+
+---
+
+## Q6 — Can a JavaScript-rendered search page be indexed at all?
+
+Yes, and Google documents it clearly
+(https://developers.google.com/search/docs/crawling-indexing/javascript/javascript-seo-basics):
+
+> "Google processes JavaScript web apps in three main phases: 1. Crawling 2. Rendering 3. Indexing"
+
+> "All pages with a `200` HTTP status code are sent to the rendering queue, no matter whether
+> JavaScript is present on the page."
+
+> "Once Google's resources allow, a headless Chromium renders the page and executes the
+> JavaScript. Googlebot parses the rendered HTML for links again and queues the URLs it finds
+> for crawling. Google also uses the rendered HTML to index the page."
+
+So client-side rendering is not itself a bar to indexing — `/search/?q=…` result pages _could_
+be indexed on their merits.
+
+One directly relevant caveat, same doc:
+
+> "When Google encounters the `noindex` tag, it may skip rendering and JavaScript execution,
+> which means using JavaScript to change or remove the robots `meta` tag from `noindex` may not
+> work as expected."
+
+> "If you _do_ want the page indexed, don't use a `noindex` tag in the original page code."
+
+Implication for this decision: if `/search/` gets a server-rendered `noindex`, Google may not
+render it at all — so its JS-generated result links are definitely not a discovery path, with or
+without `nofollow`. That further reduces the case for adding `nofollow`.
+
+---
+
+## Loose ends / things deliberately not resolved here
+
+- **The `?q=` URL space is not covered by anything decided so far.** A `noindex` on the
+  `/search/` template would apply to `/search/?q=…` too (same document), which is probably the
+  point. Removing `/search/` from the sitemap does nothing about `?q=` URLs, which were never in
+  it. Worth stating explicitly in whatever decision gets written.
+- **The Bing Webmaster Guidelines body could not be read.** If this matters to the decision,
+  it needs a human with a browser, not another fetch.
+- **`/random/` uses `noindex,nofollow` + `build: {list: never}`.** Nothing found in this research
+  justifies `nofollow` over plain `noindex`, and `sitemap: {disable: true}` would be a narrower
+  tool than `list: never` if `/random/` ever needs to be back in page collections. Out of scope
+  for #175, but noted since the two pages will inevitably be compared.
+- **No evidence was found that Google penalizes, demotes, or spam-flags a small site for having
+  one indexable internal search page.** The absence is real: I looked in the spam policies,
+  Search Essentials, the faceted navigation guide, and the crawl budget guide. The only live
+  documented risk is the soft-404 classification of the empty variant, and the documented
+  consequence of that is simply that Google drops the page from Search — i.e. roughly the same
+  outcome as `noindex`, arrived at without any action.

--- a/themes/reborn/layouts/_default/index.llmstxt.txt
+++ b/themes/reborn/layouts/_default/index.llmstxt.txt
@@ -51,7 +51,19 @@ Hand-picked, hand-ranked. If you only read a few things, read these.
 {{ end -}}
 {{- end -}}
 {{- range where site.RegularPages "Section" "" -}}
-{{- if not (in (slice "random" "search") .File.ContentBaseName) -}}
+{{/* Utility pages have nothing to tell a model, same reason they carry
+    `noindex`. See decisions/indexing.md.
+
+    Be honest about what this guard does today: nothing. It replaced a
+    hardcoded `(slice "random" "search")` that was equally inert, and the
+    inertness was measured, not assumed — blanking the condition entirely
+    produces a byte-identical `/llms.txt`. Neither page can reach this range in
+    the first place: `/random/` is `build.list: never` so it is in no page
+    collection, and `/search/` is an `_index.md` branch page so it is not a
+    RegularPage. The guard is kept because it states the rule rather than
+    listing today's two filenames, and it will actually fire the day a utility
+    page is an ordinary root-section page. */ -}}
+{{- if not .Params.noindex -}}
 - [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . | plainify }}{{ end }}
 {{ end -}}
 {{- end }}

--- a/themes/reborn/layouts/partials/head.html
+++ b/themes/reborn/layouts/partials/head.html
@@ -16,6 +16,15 @@
   <meta name="description" content="{{ . }}">
 {{ end }}
 
+{{/* Opt-in `noindex` for utility pages: pages that exist to do something
+  rather than to say something, and so have nothing to offer an index. Plain
+  `noindex`, never `noindex,nofollow`: `nofollow` would tell crawlers to stop
+  following this page's own header and footer nav. See decisions/indexing.md.
+*/}}
+{{ if .Params.noindex }}
+  <meta name="robots" content="noindex">
+{{ end }}
+
 {{ with .Site.Params.fediverse_creator }}
   <meta name="fediverse:creator" content="{{ . }}">
 {{ end }}

--- a/themes/reborn/layouts/robots.txt
+++ b/themes/reborn/layouts/robots.txt
@@ -11,14 +11,15 @@
   crawlers. The reasoning, and what we would have to see to change our minds,
   is in decisions/ai-crawlers.md.
 
-  Note what is *not* here: `/random/` carries a `noindex` meta tag and is
-  deliberately left crawlable anyway. A `Disallow` would stop the page being
-  fetched, so the `noindex` would never be read, and search engines can index a
-  blocked URL regardless on the strength of inbound links. Blocking is the
-  wrong tool for keeping a page out of an index.
+  Note what is *not* here: `/random/` and `/search/` both carry a `noindex`
+  meta tag and are deliberately left crawlable anyway. A `Disallow` would stop
+  either page being fetched, so the `noindex` would never be read, and search
+  engines can index a blocked URL regardless on the strength of inbound links.
+  Blocking is the wrong tool for keeping a page out of an index.
 
-  `/search/` has no `noindex` and is not blocked here either. Whether it should
-  be kept out of the index is a separate question from crawl policy; see #175.
+  That is the standing division of labour here: this file says who may fetch
+  what, and the `noindex` meta tag says what may be indexed. They are different
+  questions and neither substitutes for the other. See decisions/indexing.md.
 */ -}}
 User-agent: *
 Allow: /


### PR DESCRIPTION
Answers #175. `/search/` now carries `noindex` and leaves `sitemap.xml`.

## The reasoning

`/search/` is a **utility page**: it runs a search rather than saying anything, so it has nothing to offer an index. With no query it returns 200 and "Please enter a word or phrase above," which is precisely Google's documented soft-404 example ("an empty internal search result page"), and Google says soft 404s "are excluded from Search."

Note what that means: **the page was never going to be indexed either way.** The choice isn't indexed vs. not indexed, it's who decides and what the record looks like. Left alone, Google renders the page, classifies it a soft 404, and drops it, leaving a Search Console row indistinguishable from a genuinely broken page. With the tag, the same outcome is deterministic and reads as a decision. Google's JavaScript SEO doc adds that it "may skip rendering and JavaScript execution" on a `noindex` page, so the explicit version is cheaper to serve too.

It's a tidiness argument, honestly made. Nobody was being harmed by the old state.

## What didn't survive checking

The issue's premise was folklore. "Google discourages indexing internal search result pages" traces to a **March 10, 2007** Matt Cutts post and a line in the old Webmaster Guidelines. That page (`support.google.com/webmasters/answer/35769`) now **404s**, and nothing equivalent is in Search Essentials, the spam policies, the faceted navigation guide, or the crawl budget guide. All four were checked. No evidence was found that Google penalizes a small site for one indexable search page.

Two supporting facts also failed:

- **"Submitted URL marked 'noindex'" no longer exists in Search Console.** The current Page Indexing report has no Errors section and files it under *Not indexed*, with "it's fine for a URL not to be indexed for the right reasons." So a `noindex` URL in a sitemap is untidy, not an error. The removal rests on Google's positive instruction to list URLs you want ranked.
- **Google documents that it ignores `<priority>`,** so the existing `priority: 0.1` bought nothing. It's gone.

## What's covered, and what isn't

`search.js` reads a `q` param, so `/search/?q=elixir` is a real, shareable, unbounded URL space. The **meta tag covers all of it** (same document); the **sitemap change covers none of it** (those URLs were never listed). Worth not misreading later. Separately, `head.html` already emits a canonical pointing every `?q=` variant back at bare `/search/`, which is a big part of why the old state was defensible.

## Mechanism

- Opt-in `.Params.noindex`, read by `head.html`. Plain `noindex`, never `noindex,nofollow`: `nofollow` would tell crawlers to stop following this page's own header and footer nav, and buys nothing since the result links are client-side and may never be rendered anyway. The "long-lived noindex becomes nofollow" claim is not documented first-party anywhere.
- `sitemap: {disable: true}`, Hugo v0.125.0+, verified against the `config.SitemapConfig` struct and embedded template at tag v0.161.1. It drops the `<url>` entry while the page still renders and stays in every page collection. (`build: {list: never}` would also work but is a bigger hammer; `build: {render: link}` is a trap that keeps the page in the sitemap while never writing it to disk.)

## Verifier fix, caused by this change

`bin/verify-og-images.mjs` skipped any `noindex` page, using that tag as a proxy for "emits no social tags at all." The proxy held only while `/random/` was the sole `noindex` page. `/search/` renders through `head.html` and advertises a real card that the manifest really generates, so under the old rule **that card would have silently dropped out of coverage** the moment this shipped. That's exactly the broken-share failure the script exists to catch. The skip now tests the condition it always meant: a `noindex` page is excused for having *no* `og:image`, never a broken one.

Confirmed by the counts: the verifier now reports 520 pages / 190 skipped, where the structured-data verifier (unchanged, still using the old whole-page skip) reports 519 / 191. That one page is `/search/`, moving from skipped to checked.

## Verification

- `public/search/index.html` carries the robots meta; `/search/` and `/random/` are the only two pages on the site that do.
- `sitemap.xml`: 497 → 496 URLs, no `/search/` entry.
- `node bin/verify-og-images.mjs` → "all social images resolve," with `/search/` now checked.
- `node bin/verify-structured-data.mjs` → passes unchanged.
- `/llms.txt` byte-identical.

## Docs

- **`decisions/indexing.md`** (new) — the decision, the discounted folklore, the `?q=` coverage, Hugo mechanics, and why `/random/` expresses the same intent through different machinery.
- **`docs/research-search-page-indexing.md`** (new) — 500+ lines of primary-source evidence, every claim with a URL, with weak/dated/absent evidence flagged as such. Kept separate because it's evidence, not a decision, and #174 will want it.
- **`CONTEXT.md`** — adds **Utility page**. This is the term that makes #174 tractable: a tag page with two posts is *not* a utility page, it's an index page with thin content, which is a different problem argued from different documents. Naming the category we're acting on here makes it harder to over-apply there.
- `robots.txt` template, `ai-crawlers.md`, `og-images.md`, `decisions/README.md` updated. The robots.txt comment deferring to #175 is replaced by the standing crawl-vs-index distinction.

## One thing I got wrong along the way

I pitched folding `/llms.txt`'s hardcoded `(slice "random" "search")` into the new flag as collapsing "three separate hardcodings." Measuring it showed that filter was already **dead code**: blanking the condition entirely produces a byte-identical `/llms.txt`, because `/random/` is `build: {list: never}` (in no page collection) and `/search/` is an `_index.md` branch page (not a `RegularPage`). It's still swapped to `.Params.noindex`, since stating the rule beats listing today's two filenames and it will actually fire if a utility page is ever an ordinary root-section page, but the template comment now says plainly that it does nothing today, measured rather than assumed.

## Not decided here

Thin tag and series term pages stay in #174. The mechanism transfers (`head.html` can grow an `or` condition); the soft-404 reasoning does not, because a term page listing two real posts isn't empty.