### PR TITLE
Give /random/ its authored title, description, and plain noindex (#188)

### DIFF
--- a/decisions/indexing.md
+++ b/decisions/indexing.md
@@ -79,7 +79,8 @@ Related things worth not repeating:
 
 **Preferred:** `<meta name="robots" content="noindex">`.
 
-**Rejected:** `noindex,nofollow`, which is what `/random/` uses.
+**Rejected:** `noindex,nofollow`, which is what `/random/` used to hardcode
+until [#188](https://github.com/zorn/mikezornek.com/issues/188).
 
 **Why:** `nofollow` is documented as "do not follow the links on this page," and
 on `/search/` that would include the site's own header and footer navigation.
@@ -111,23 +112,51 @@ of why the old state was defensible.
 
 ---
 
-## `/random/` says the same thing a different way
+## `/random/` keeps its standalone head, and copies three tags into it
 
-`/random/` is the other utility page, and it expresses the identical intent
-through completely different machinery: a hardcoded `noindex,nofollow` in its
-own standalone layout, and `build: {list: never}` rather than
-`sitemap: {disable: true}`.
+**Preferred:** `layout: random` stays a standalone document, and hand-copies
+`head.html`'s title, description, and `noindex` tags.
 
-This is left alone on purpose. `layout: random` is a full standalone template
-that never loads `head.html`, so the `.Params.noindex` flag could not emit its
-tag even if we wanted it to. `/random/` does carry `noindex: true` in front
-matter regardless, as a declaration rather than a mechanism, so that anything
-reasoning about utility pages has one flag to read.
+**Rejected:** routing it through `baseof.html` so the shared head reaches it.
+
+**Why:** `/random/` is the other utility page, and it expresses the identical
+intent through different machinery. Until
+[#188](https://github.com/zorn/mikezornek.com/issues/188) that machinery had
+drifted: the layout hardcoded `<title>Random Post</title>` and
+`noindex,nofollow`, and dropped the `description` the content file authored,
+making it the only rendered page on the site without a `meta description`. Bing's
+site scan of 2026-08-03 flagged it.
+
+Routing it through `baseof.html` would have fixed all three at once, and is not
+possible without moving other pieces first. `content/random.md` sets
+`build: {list: never}`, which keeps the page out of `site.Pages` and therefore
+out of `og-manifest.json`, so `bin/og-images.mjs` never draws it a card. A page
+that emitted `head.html`'s `og:image` would advertise one anyway, and
+`bin/verify-og-images.mjs` would fail the build. That is the hazard
+`_default/index.ogmanifest.json` already documents, and `/random/` is the page
+it was written about.
+
+Even setting that aside, it would be the wrong trade. The page's whole job is to
+bounce the visitor to a post; the shared head would have it fetch the CSS
+bundle, two preloaded fonts, Plausible, and the theme JS for a document nobody
+looks at.
+
+So the standalone head stays, and the three tags that cost nothing to serve are
+copied into it. The `noindex` now reads `.Params.noindex` rather than being
+hardcoded, which makes the front matter flag this page's mechanism and not just
+its declaration. Everything that fetches a subresource stays out.
+
+**The cost, stated plainly:** those tags are a hand-copy, and nothing enforces
+that they track `head.html`. A change to the description chain or the title
+format has to be made twice. That is the price of the standalone head, and it is
+small only because the copied set is deliberately kept to three tags.
 
 Worth knowing if `/random/` is ever revisited: `build: {list: never}` is a much
-bigger hammer than it needs. It removes the page from _every_ page collection,
-where `sitemap: {disable: true}` would remove only the sitemap entry. The
-difference has not mattered yet.
+bigger hammer than the sitemap needs. It removes the page from _every_ page
+collection, where `sitemap: {disable: true}` would remove only the sitemap
+entry. That difference used to be inert; it is now the thing keeping the page
+out of the card manifest, so swapping it is a prerequisite for routing through
+`baseof.html`, not an independent tidy-up.
 
 ---
 

--- a/decisions/indexing.md
+++ b/decisions/indexing.md
@@ -124,8 +124,10 @@ intent through different machinery. Until
 [#188](https://github.com/zorn/mikezornek.com/issues/188) that machinery had
 drifted: the layout hardcoded `<title>Random Post</title>` and
 `noindex,nofollow`, and dropped the `description` the content file authored,
-making it the only rendered page on the site without a `meta description`. Bing's
-site scan of 2026-08-03 flagged it.
+making it the only page rendered through the theme without a `meta description`.
+Bing's site scan of 2026-08-03 flagged it. (The 189 alias redirect stubs have no
+description either. They are bare meta-refresh documents rather than pages, and
+the same distinction is why both build verifiers skip them.)
 
 Routing it through `baseof.html` would have fixed all three at once, and is not
 possible without moving other pieces first. `content/random.md` sets
@@ -154,9 +156,11 @@ small only because the copied set is deliberately kept to three tags.
 Worth knowing if `/random/` is ever revisited: `build: {list: never}` is a much
 bigger hammer than the sitemap needs. It removes the page from _every_ page
 collection, where `sitemap: {disable: true}` would remove only the sitemap
-entry. That difference used to be inert; it is now the thing keeping the page
-out of the card manifest, so swapping it is a prerequisite for routing through
-`baseof.html`, not an independent tidy-up.
+entry. An earlier draft of this record called that difference one that "has not
+mattered yet." That was wrong when it was written, and #188 did not change it:
+the extra reach is exactly what keeps `/random/` out of `og-manifest.json`, and
+has since the manifest existed. So swapping the two is a prerequisite for
+routing through `baseof.html`, not an independent tidy-up.
 
 ---
 

--- a/themes/reborn/layouts/_default/random.html
+++ b/themes/reborn/layouts/_default/random.html
@@ -1,10 +1,46 @@
 <!doctype html>
 <html lang="{{ site.Language.Locale }}">
   <head>
+    {{/* This page deliberately does not render through `baseof.html` and
+      `partials/head.html`. Its whole job is to bounce the visitor to a post,
+      and the shared head would have it fetch the CSS bundle, the preloaded
+      fonts, Plausible, and the theme JS for a document nobody ever looks at.
+
+      The load-bearing reason is structural, though. `content/random.md` sets
+      `build: {list: never}`, which keeps this page out of `site.Pages` and so
+      out of `og-manifest.json`. A page emitting `head.html`'s `og:image` would
+      advertise a social card the generator never draws, and
+      `bin/verify-og-images.mjs` would fail the build. That is the hazard the
+      note in `_default/index.ogmanifest.json` describes.
+
+      The cost is that the tags below are hand-copies of `head.html` and have to
+      be kept in step with it by hand. Keep them to metadata: anything that
+      fetches a subresource belongs on a page that is meant to be read. See
+      decisions/indexing.md.
+    */}}
     <meta charset="utf-8">
-    <meta name="robots" content="noindex,nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Random Post</title>
+    <title>{{ printf "%s • %s" .Title site.Title }}</title>
+
+    {{/* Same chain and the same escaping as `head.html`. `plainify` alone
+      returns `template.HTML` and Go stops escaping, so a bare `&` would ship
+      raw. See decisions/page-metadata.md.
+    */}}
+    {{ with or .Description site.Params.description | plainify | htmlUnescape }}
+      <meta name="description" content="{{ . }}">
+    {{ end }}
+
+    {{/* Driven by the `noindex: true` front matter rather than hardcoded, so
+      this page's declaration and its mechanism are the same thing that every
+      other utility page uses. Plain `noindex`, never `noindex,nofollow`:
+      `nofollow` would tell crawlers to stop following the links in the body
+      below, which is the one crawl path this page offers. See
+      decisions/indexing.md.
+    */}}
+    {{ if .Params.noindex }}
+      <meta name="robots" content="noindex">
+    {{ end }}
+
     {{- $posts := where .Site.RegularPages "Type" "in" .Site.Params.mainSections }}
     <script>
       const posts = [


### PR DESCRIPTION
Closes #188. `/random/` now emits the description `content/random.md` authors, the site-suffixed title every other page gets, and plain `noindex`.

## The question the issue left open

Whether the standalone head is deliberate. It is, and for a reason the issue didn't have: routing through `baseof.html` is **blocked**, not merely costly.

`content/random.md` sets `build: {list: never}`, which keeps the page out of `site.Pages` and therefore out of `og-manifest.json`, so `bin/og-images.mjs` never draws it a card. A page emitting `head.html`'s `og:image` would advertise one anyway, and `bin/verify-og-images.mjs` would fail the build. That is precisely the hazard `_default/index.ogmanifest.json` already documents, and `/random/` is the page it was written about. Unblocking it means swapping `build: {list: never}` for `sitemap: {disable: true}`, which turns a consistency fix into a change across three decision records.

Even setting that aside it would be the wrong trade: the page's whole job is to bounce the visitor to a post, and the shared head would have it fetch the CSS bundle, two preloaded fonts, Plausible, and the theme JS for a document nobody reads.

## What changed

The three tags that cost nothing to serve are copied into the standalone head instead:

- **Title** now uses the shared `{{ printf "%s • %s" .Title site.Title }}` format rather than a hardcoded `<title>Random Post</title>`.
- **Description** renders through the same `or .Description site.Params.description | plainify | htmlUnescape` chain as `head.html`, escaping included. This is the tag Bing's Aug 3 scan flagged.
- **Robots** is plain `noindex`, and now reads `.Params.noindex` rather than being hardcoded. That promotes the front matter flag from a declaration to this page's actual mechanism, which is what `decisions/indexing.md` wanted all along.

Nothing that fetches a subresource was added.

## The cost, written down

Those three tags are a hand-copy, and nothing enforces that they track `head.html`. A change to the description chain or the title format has to be made twice. `decisions/indexing.md` now records that, alongside a correction to its own earlier note that the `build: {list: never}` hammer "has not mattered yet" — it is the thing keeping the page out of the card manifest, so swapping it is a prerequisite for ever routing through `baseof.html`, not an independent tidy-up.

## Verification

- Rendered `public/random/index.html` carries all three tags; `/random/` and `/search/` are still the only two pages with a robots meta, both now plain `noindex`.
- A sweep of `public/` for pages with no `meta description` returns only the 189 alias redirect stubs. `/random/` was the last real page on the list.
- `/random/` is still absent from `sitemap.xml`.
- `hugo`, `bin/og-images.mjs`, `bin/verify-og-images.mjs`, and `bin/verify-structured-data.mjs` all pass. Verifier counts are unchanged (520/190 and 519/191), since `/random/` still emits no social tags and is still skipped by both.
- Prettier clean.
