### PR TITLE
Give every indexable page exactly one h1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,9 @@ written. Consult (and maintain) them when relevant:
   their reasoning so they aren't rediscovered later. Notably `word-choice.md`
   codifies house-style spellings/word forms (e.g. `lifecycle`). **Check this
   before writing or editing prose** and follow the preferred forms; add a new
-  entry when a new style decision comes up.
+  entry when a new style decision comes up. `headings.md` is the other one that
+  bites while authoring: the layout renders each page's `<h1>` from `title`, so
+  markdown bodies start at `##` and never write a `#`.
 - `playbook/` — repeatable process docs. `promotion.md` lists where and how
   Mike shares a new post (Mastodon, LinkedIn, Elixir Slack/Forum, Reddit, etc.)
   and a share-template format.

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -77,6 +77,14 @@ node bin/og-images.mjs
 echo "Verifying social images..."
 node bin/verify-og-images.mjs
 
+# Fail the build if any page renders zero or two-plus h1 tags. The layout owns
+# the h1 (see decisions/headings.md), which took a sweep of 23 content files to
+# make true and nothing but this keeps true: a markdown body that opens with `#`
+# renders a second h1, and a new layout that forgets the heading renders none.
+# Neither is an error and neither is visible on the page. See #186.
+echo "Verifying headings..."
+node bin/verify-headings.mjs
+
 # Fail the build if the page's JSON-LD is malformed, incomplete, or references
 # an entity no node on that page declares. Structured data is never rendered, so
 # a mistake in it is invisible in a way even a broken og:image is not: nobody

--- a/bin/verify-headings.mjs
+++ b/bin/verify-headings.mjs
@@ -1,0 +1,157 @@
+// Asserts that every rendered page has exactly one `<h1>`.
+//
+// `decisions/headings.md` settled that the layout owns the h1 and markdown
+// bodies start at `##`. Enforcing that took a sweep of 23 content files, and
+// nothing about the setup keeps it swept: a post that opens with a `#` renders a
+// second h1, and a new layout that forgets the heading renders none. Neither
+// shows up as an error, and neither is visible to anyone reading the page.
+//
+// That is the same class of silent failure as a 404ing og:image (#159) or
+// malformed JSON-LD, and it gets the same treatment: a check on every build.
+// See #186 for the audit that prompted it and #156 for the wider page-metadata
+// check this belongs with.
+//
+// Usage: node bin/verify-headings.mjs [publish-dir]
+
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+
+const PUBLISH_DIR = process.argv[2] ?? "public";
+
+// Matches an opening `<h1>` or `<h1 class="...">`, and nothing else. Without the
+// trailing character class this would also count `<h1abc`, and without the
+// leading `<` it would count the closing tag, doubling every page's total.
+const H1_OPEN = /<h1[\s>]/gi;
+
+// Hugo writes a bare refresh stub for every `aliases` entry: a title, a
+// canonical link, and a meta refresh, with none of the theme's layout. There are
+// around 190 of them for the pre-2020 URL scheme. They are redirects rather than
+// pages, so having no heading is correct, not a defect.
+//
+// The refresh tag alone is not enough to identify one. A post writing about
+// redirects could emit that tag as raw inline HTML, and matching on it by itself
+// would drop that page out of the check silently — the worst failure available
+// to a script whose whole job is to notice. Hugo's stub is a `<head>` and
+// nothing else, so requiring no `<body>` separates the two exactly.
+const REFRESH_TAG = /<meta\s+http-equiv="refresh"/i;
+const BODY_TAG = /<body[\s>]/i;
+
+function isAliasStub(html) {
+  return REFRESH_TAG.test(html) && !BODY_TAG.test(html);
+}
+
+// Files allowed to render no h1, by path under the publish dir. Two things end
+// up here: a page that genuinely should not have one, and a standalone HTML
+// asset that is not a page at all (see the missing-h1 report below).
+//
+// `/random/` is the only one and is not really a page: it is a redirect shim
+// that bounces the visitor to a random post, whose body exists only as a
+// fallback link for when the script does not run. It gets an entry here rather
+// than a broader "skip noindex pages" rule, because `/search/` is noindex too
+// and does carry an h1 — a rule loose enough to excuse `/random/` by category
+// would quietly stop checking `/search/` as well.
+const NO_H1_ALLOWED = new Set(["random/index.html"]);
+
+function log(message) {
+  console.log(`[verify-headings] ${message}`);
+}
+
+async function* htmlFiles(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* htmlFiles(path);
+    } else if (entry.name.endsWith(".html")) {
+      yield path;
+    }
+  }
+}
+
+async function main() {
+  const missing = [];
+  const duplicated = [];
+  const unusedAllowances = new Set(NO_H1_ALLOWED);
+  let pages = 0;
+  let skipped = 0;
+
+  for await (const file of htmlFiles(PUBLISH_DIR)) {
+    const html = await readFile(file, "utf8");
+
+    if (isAliasStub(html)) {
+      skipped += 1;
+      continue;
+    }
+    pages += 1;
+
+    const key = relative(PUBLISH_DIR, file).split(sep).join("/");
+    const count = (html.match(H1_OPEN) ?? []).length;
+
+    if (count === 1) continue;
+
+    if (count === 0) {
+      if (NO_H1_ALLOWED.has(key)) {
+        unusedAllowances.delete(key);
+        continue;
+      }
+      missing.push(`/${key}`);
+    } else {
+      duplicated.push(`/${key}  (${count} h1s)`);
+    }
+  }
+
+  log(`${pages} pages checked, ${skipped} alias redirect stubs skipped`);
+  let failed = false;
+
+  const report = (label, entries) => {
+    failed = true;
+    log(`ERROR: ${entries.length} ${label}:`);
+    for (const entry of entries.slice(0, 20)) log(`  ${entry}`);
+    if (entries.length > 20) log(`  ...and ${entries.length - 20} more`);
+  };
+
+  // A run that found no pages is a broken check, not a passing one — the same
+  // no-op-that-prints-success failure bin/verify-og-images.mjs guards against.
+  if (pages === 0) {
+    failed = true;
+    log(
+      `ERROR: found no pages to check under ${PUBLISH_DIR}. Either the site did not build or the publish dir is wrong.`,
+    );
+  }
+
+  // This walks every `.html` under the publish dir, so a standalone HTML asset
+  // shipped alongside a post — an OmniOutliner or Keynote export, say — reads as
+  // a page with no heading and lands here. There is no reliable marker that
+  // separates a rendered page from one of those, and failing on the unknown case
+  // beats guessing past it, so the message carries the alternative instead.
+  if (missing.length > 0) {
+    report(
+      "page(s) render no h1. The layout owns it: see decisions/headings.md. " +
+        "If one of these is not a page but an HTML asset, add it to NO_H1_ALLOWED",
+      missing,
+    );
+  }
+  if (duplicated.length > 0) {
+    report(
+      "page(s) render more than one h1, usually a `#` in markdown that should be `##`",
+      duplicated,
+    );
+  }
+
+  // An allowance nobody uses is a stale exception that would silently excuse a
+  // future page at that path. Fail so it gets deleted with the page it covered.
+  if (unusedAllowances.size > 0) {
+    report("stale entr(ies) in NO_H1_ALLOWED — the page(s) now have an h1", [
+      ...unusedAllowances,
+    ]);
+  }
+
+  if (failed) process.exit(1);
+  log("every page has exactly one h1");
+}
+
+try {
+  await main();
+} catch (error) {
+  log(`ERROR: ${error.message}`);
+  process.exit(1);
+}

--- a/bin/verify-og-images.mjs
+++ b/bin/verify-og-images.mjs
@@ -43,7 +43,17 @@ const IMAGE_TAG =
 // canonical link, and a meta refresh, with none of the theme's head partial.
 // There are around 190 of them for the pre-2020 URL scheme. They are redirects
 // rather than pages, so having no social image is correct, not a defect.
-const ALIAS_STUB = /<meta\s+http-equiv="refresh"/i;
+//
+// The refresh tag alone is not enough to identify one. A post writing about
+// redirects could emit that tag as raw inline HTML, and matching on it by itself
+// would drop that page out of the check silently. Hugo's stub is a `<head>` and
+// nothing else, so requiring no `<body>` separates the two exactly.
+const REFRESH_TAG = /<meta\s+http-equiv="refresh"/i;
+const BODY_TAG = /<body[\s>]/i;
+
+function isAliasStub(html) {
+  return REFRESH_TAG.test(html) && !BODY_TAG.test(html);
+}
 
 // Some noindex pages do not load the theme's head partial at all and so emit no
 // social tags. `/random/` is the example: a standalone layout that bounces the
@@ -104,7 +114,7 @@ async function main() {
   for await (const file of htmlFiles(PUBLISH_DIR)) {
     const html = await readFile(file, "utf8");
 
-    if (ALIAS_STUB.test(html)) {
+    if (isAliasStub(html)) {
       skipped += 1;
       continue;
     }

--- a/content/contact.md
+++ b/content/contact.md
@@ -5,8 +5,6 @@ sectionHighlight: Contact
 layout: onepage
 ---
 
-{{< sr-only-title "Contact" >}}
-
 **Email:** <mike@mikezornek.com>
 
 **Mastodon:** <https://jawns.club/@zorn>

--- a/content/posts/2019/1/designing-a-modern-swift-network-stack-video-and-slides/index.md
+++ b/content/posts/2019/1/designing-a-modern-swift-network-stack-video-and-slides/index.md
@@ -15,7 +15,7 @@ I had a great time doing this networking design talk for the local [Philly Cocoa
 - [Video on Vimeo](https://vimeo.com/311520171) 44 minutes
 - Slides [PDF](modern-ios-network-zornek-slides.pdf) / [SpeakerDeck](https://speakerdeck.com/zorn/designing-a-modern-swift-network-stack)
 
-# Designing a Modern Swift Network Stack
+## Designing a Modern Swift Network Stack
 
 When an app is young and has simple networking needs it's not uncommon to use URLSession tasks directly inside of a view controller. However as the app needs grow to include things like authenticated requests, token renewal, testing, cancellation, caching and more -- you'll want to have a more defined networking stack to lean on. On a client project over the summer, the iOS team and I started to document a networking wish list and over the past few months we've started to execute it, first on some smaller features and a demos app. Now we are preparing for a new greenfield iOS app where we should be able to hit the ground running with our new ideas.
 

--- a/content/posts/2019/1/network-design-talk-at-philly-cocoaheads.md
+++ b/content/posts/2019/1/network-design-talk-at-philly-cocoaheads.md
@@ -15,7 +15,7 @@ Thursday, January 10, 2019
 399 Market Street, Suite 360  
 [Meetup RSVP](https://www.meetup.com/PhillyCocoaHeads/events/kvsmnqyzcbnb/)
 
-> # Designing a Modern Swift Network Stack
+> ## Designing a Modern Swift Network Stack
 >
 > When an app is young and has simple networking needs it's not uncommon to use URLSession tasks directly inside of a view controller. However as the app needs grow to include things like authenticated requests, token renewal, testing, cancelation, caching and more -- you'll want to have a more defined networking stack to lean on. On a client project over the summer, the iOS team and I started to document a networking wish list and over the past few months we've started to execute it, first on some smaller features and then a demos app. Now we are preparing for a new greenfield iOS app where we should be able to hit the ground running with our new ideas.
 >

--- a/content/posts/2021/12/next-project-filters/index.md
+++ b/content/posts/2021/12/next-project-filters/index.md
@@ -65,7 +65,7 @@ With awareness of these recent failures, I am trying to be more mindful and inte
 
 **The product does not need to be software.** While I am a developer and empowered to deliver software-based solutions, I am not against building educational products or other assets/toolkits/solutions.
 
-# My Superpowers
+## My Superpowers
 
 In addition to considering the above product filters, it is also essential to identify one's superpowers. We each have a unique background and collage of skills/experiences. Understanding how you can contribute to a given product idea is key to its choice.
 

--- a/content/posts/2022/9/26-liveview-native/index.md
+++ b/content/posts/2022/9/26-liveview-native/index.md
@@ -76,7 +76,7 @@ There was also a reaction of "this feels like a lot of complexity with many fail
 
 However, this tool is not really built for them. So who is this being built for? Time for hot takes.
 
-# What pain is LiveView Native is trying to solve?
+## What pain is LiveView Native is trying to solve?
 
 {{< figure src="hot-take.jpg" width="70%"
   alt="A glowing roadside marquee at dusk reading 'Hot Take House,' with a neon 'Open 24 Hours' sign below." >}}

--- a/content/posts/2023/3/potential-consulting-client-questions/index.md
+++ b/content/posts/2023/3/potential-consulting-client-questions/index.md
@@ -138,7 +138,7 @@ Is there any high-level documentation for the structure or architecture of the a
 
 > Why: It will be hard to grok any complex architecture during a single meeting, but getting an overview and some specific guidance on what you'd likely be contributing to is helpful.
 
-# Understanding My Role
+## Understanding My Role
 
 Will I be in an individual contributor role or a team management role? What does that role look like, and what would my responsibilities be?
 

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -5,17 +5,17 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-# Active Personal Projects
+## Active Personal Projects
 
 [Flick](https://github.com/zorn/flick) is an in-progress side project that aims to provide a simple web app, built using Elixir and Phoenix LiveView, that will to provide a tools to build and capture ranked voting.
 
 Specifically this project is being constructed to help the [Elixir Book Club](https://elixirbookclub.github.io/website/) pick books.
 
-## Mike Zornek.com
+### Mike Zornek.com
 
 This very website is an open source project using tech including: Hugo, HTML/CSS, GitHub, CircleCI, Linode and Apache. [Background](/projects/mikezornek-site/)
 
-# Past Personal Projects
+## Past Personal Projects
 
 - [StudyHall](https://github.com/studyhall-project/studyhall) (Elixir, Svelte, Ash)
 - [Course Dreamers](https://coursedreamers.com)
@@ -34,7 +34,7 @@ This very website is an open source project using tech including: Hugo, HTML/CSS
 - [ProfitTrain / Billable](/projects/profittrain/) (macOS app)
 - [MegaManEffect](/projects/megamaneffect/) (macOS app)
 
-# Past Client Projects
+## Past Client Projects
 
 - [TrafficCast](/projects/trafficcast/) (iOS App)
 - [ROAR AlwaysOn](/projects/roar/) (Elixir Phoenix web app)

--- a/content/projects/agency.md
+++ b/content/projects/agency.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-## Agency Projects
-
 While a full time employee at a pair of large agencies I had the opportunity to work on many iOS projects. However, because of NDA clauses I can not reveal actual clients. Instead I'll describe the projects in more generic terms:
 
 - **iPad Roofing Preview App** - would let people take a photo of their house, choose roofing tile and preview what it would look like and cost.

--- a/content/projects/dex.md
+++ b/content/projects/dex.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-## Dex
-
 Dex was my first real app for iOS. It was a Pokemon reference tool that showed weaknesses, strengths, and stats. Sadly it was taken down from the store at Nintendo legal's request. It was a huge success though (~1 million downloads) and was the source of my talk on [iOS Monetization](https://vimeo.com/28678889).
 
 <iframe src="https://player.vimeo.com/video/377633437" width="640" height="960" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>

--- a/content/projects/elixir_club.md
+++ b/content/projects/elixir_club.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-# Elixir Club
-
 ElixirClub was an outcome-oriented community website that hoped to help Elixir developers finish their side projects. I kicked off the project in December of 2022 and ran it for a few months but did not get the traction I needed and decided to shut down the site about six months later.
 
 You can check out this kickoff video for a sense of what I was trying to build.

--- a/content/projects/elixir_focus.md
+++ b/content/projects/elixir_focus.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-# Elixir Focus / Phoenix by Example
-
 For a while I was considering getting into the paid-for educational content space, targeting Elixir developers. I started with a site called Phoenix by Example, but then migrated it to a new name of Elixir Focus.
 
 I blogged, build some demo projects and did some talks.

--- a/content/projects/franklin.md
+++ b/content/projects/franklin.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-# Franklin
-
 Franklin was a project written in Elixir, Phoenix, and LiveView. It was an intentionally over-engineered blog application, an opportunity for me to play around and learn how to build software in an event-sourced / CQRS model using [Commanded](https://github.com/commanded/commanded).
 
 {{<youtube dGKxhR-h7PM>}}

--- a/content/projects/geo.md
+++ b/content/projects/geo.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-## GEO
-
 GEO was a team project from around 2010 that came out of an experimental entrepreneurial group at IndyHall. The basic idea is that GEO was an iOS game that would track your location and encourage you to walk around your neighborhood for exercise. As you walked around you'd fight monsters, level up and find treasure. The idea was [ahead of it's time](https://pokemongolive.com/en/) but it never really gained any traction in our simple execution.
 
 I don't seem to have footage of the final build but this preview will give you an idea of where we were headed:

--- a/content/projects/guildflow.md
+++ b/content/projects/guildflow.md
@@ -6,8 +6,6 @@ layout: onepage
 aliases: /projects/club-house-hosting/
 ---
 
-# Guildflow
-
 <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/469827044?h=38e11df892&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="Demoing Guildflow at IndyHall Show and Tell"></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 
 Guildflow combined my love of meetup groups with the aspirations of the [IndieWeb](https://indieweb.org/IndieWeb).

--- a/content/projects/megamaneffect.md
+++ b/content/projects/megamaneffect.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-## MegaManEffect
-
 My first "real" MacOS app. Based on the Nintendo game MegaMan 2, the MegaManEffect would play a fun animation as you launched apps on Mac OS X. I wrote the app at MacHack (getting 2nd place in the hack contest) and then a year later it blew up on the internet, even getting featured on Attack of the Show.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/U6q3vfQKTJI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/content/projects/mikezornek-site.md
+++ b/content/projects/mikezornek-site.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-# Mike Zornek (Personal Website)
-
 My personal site is far from a complex project, but it is an example of me and my work.
 
 The site is built using [Hugo](https://gohugo.io/) a static website generator with a custom theme handcrafted by myself. The code is open source and [hosted on GitHub](https://github.com/zorn/mikezornek.com). Changes to `master` result in an automated publishing script ran by [CircleCI](https://circleci.com/) with the final contents published to [Linode](https://www.linode.com/) which hosts the website using a simple [Apache](https://httpd.apache.org/) VM node.

--- a/content/projects/owldeck.md
+++ b/content/projects/owldeck.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-## OwlDeck
-
 The OwlDeck project was to build a new macOS presentation tool geared towards programmers and geeks who need to display code and love Markdown.
 
 I worked on OwlDeck for a few months but inevitably ran into too many headaches with the low level text system of macOS and felt the project unmaintainable. I did learn a lot through the process, including writing my own Markdown parser in Swift which was a plus.

--- a/content/projects/philly-cocoaheads/_index.md
+++ b/content/projects/philly-cocoaheads/_index.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-## Philly CocoaHeads Website (Hugo)
-
 {{< figure src="pc-home.png" alt="The Philly CocoaHeads home page, a clean single-column layout introducing the group and its upcoming meetups." >}}
 
 {{< figure src="pc-about.png" alt="The Philly CocoaHeads about page, describing the group's history and what to expect at a meeting." >}}

--- a/content/projects/profittrain.md
+++ b/content/projects/profittrain.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-## ProfitTrain
-
 ProfitTrain (formerly Billable) was a time tracking and invoice tool for Mac OS X. While simple, it found an audience and was a very successful product for me.
 
 Sadly when I joined the [Shindig](/projects/shindig/) team my time was full of Shindig responsibilities and I could not find time to keep ProfitTrain up-to-date. I decided to sell ProfitTrain to RazorAnt hoping it would find some updates. It saw some, but sadly not nearly as many as I wanted. It was discontinued by RazorAnt in 2018.

--- a/content/projects/roar/_index.md
+++ b/content/projects/roar/_index.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-## ROAR For Good
-
 [AlwaysOn](https://www.roarforgood.com/) is a security platform for hotels and its employees. After hitting a panic button, hotel security is given an exact, room-specific location of the event.
 
 ![AlwaysOn](roar.png "AlwaysOn")

--- a/content/projects/shindig.md
+++ b/content/projects/shindig.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-## Shindig
-
 Shindig was a startup I participated in as co-owner and CTO that provided a platform that would generate mobile apps (iOS, Android and Web) for attendees of conference-like events. The platform also included an Admin backend for managing all the data written in Rails. I did most of the Rails work and supervised the iOS and Android projects.
 
 While we were about to run some events to satisfied customers, in time we shut down the company as we were not selling enough to match the money / effort we were making elsewhere doing things like freelance consulting. I did a longer retrospective of Shindig, which you can watch here:

--- a/content/projects/trafficcast.md
+++ b/content/projects/trafficcast.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-## TrafficCast
-
 > [TrafficCast](http://www.trafficcast.com/) is the leader in travel time forecasting and traffic information, developing technology, applications and content based on advanced digital traffic data. TrafficCast serves the interactive, mobile, enterprise and public sector markets.
 
 I worked with TrafficCast for over 2 years as a consultant, helping out with two major iOS projects and other general code maintenance. The highlight for me was an opportunity to rebuild their network stack and share the final design through a few different presentations.

--- a/content/projects/twizshow.md
+++ b/content/projects/twizshow.md
@@ -5,8 +5,6 @@ sectionHighlight: Projects
 layout: onepage
 ---
 
-## TwizShow
-
 TwizShow was an iOS game I made that would generate a game show based on your Twitter data. While a ton of fun to build it never really saw any traction and was pulled from the store when Twitter changed their API rules.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/-mXek4xHiYk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -12,4 +12,5 @@ One file per topic. Add a new file when a new kind of decision comes up.
 - [structured-data.md](structured-data.md) — the JSON-LD entity the home page and blog posts declare, and what to expect from it
 - [llms-txt.md](llms-txt.md) — the generated `/llms.txt`, and why it is cheap optionality rather than a channel
 - [feeds.md](feeds.md) — why the RSS feeds are capped at 50 items, stay full-text, and how their forked template is kept in sync with Hugo's
+- [headings.md](headings.md) — why the layout renders each page's `<h1>` and markdown starts at `##`
 - [word-choice.md](word-choice.md) — preferred spellings and word forms

--- a/decisions/headings.md
+++ b/decisions/headings.md
@@ -1,0 +1,94 @@
+# Headings
+
+Every indexable page renders exactly one `<h1>`, and the layout is what renders
+it. Markdown in `content/` starts at `##`.
+
+---
+
+## The layout owns the h1, not the content
+
+**Preferred:** Each layout emits `<h1>{{ .Title }}</h1>`. Markdown bodies open
+at `##`.
+
+**Rejected:** Letting each markdown file write its own `#` heading.
+
+**Why:** Content-owned h1s are opt-in, and the opt-in did not happen. A Bing
+Webmaster Tools scan in August 2026 flagged missing and duplicated h1s; a full
+audit of the build found **39 indexable pages with no `<h1>` at all** and
+**6 with more than one** (issue #186).
+
+The 39 came from two templates that rendered no heading of their own:
+
+- `_default/list.html` — `/posts/` plus its 23 pagination pages opened straight
+  into the post cards.
+- `_default/onepage.html` — rendered only `.Content`, so `/follow/`, `/now/`,
+  `/talks/`, `/values/`, and eleven `/projects/*` pages had nothing above the
+  body text.
+
+Worse than the gap was the inconsistency it produced. Three different answers to
+the same question were live at once: `contact.md` reached for a
+`{{< sr-only-title >}}` shortcode, `elixir-consulting.md` got an incidental h1
+from the styling inside `{{< consulting-quote >}}`, five project pages wrote a
+`#` in markdown, and the rest wrote nothing. `dex.md` opened with `## Dex`,
+duplicating its own front-matter title one level too deep with no h1 above it.
+
+`_default/single.html` and `_default/taxonomy.html` already worked this way, so
+this is the existing pattern finishing its spread rather than a new one.
+
+The cost is real and was accepted: the fix visibly changed 15 pages that used to
+open with body text, and it required sweeping every markdown file that had been
+supplying its own heading. That sweep is a one-time price. The alternative,
+asking every future page to remember an `#` line, is a recurring one.
+
+---
+
+## The `sr-only-title` shortcode is gone
+
+**Preferred:** Delete it. `onepage.html` renders a visible h1 for every page.
+
+**Rejected:** Keep it around for pages that want the heading hidden.
+
+**Why:** It existed to give `/contact/` an h1 that screen readers announce but
+sighted readers do not see. Once the layout renders the heading unconditionally,
+the shortcode's only remaining job is suppressing a heading the page should
+have, and a second way to declare an h1 is exactly the ambiguity this decision
+removes. `/contact/` now shows "Contact" like every other page.
+
+`home.html` still emits `<h1 class="sr-only">Who is Mike Zornek?</h1>`. That one
+stays: the home page's visual identity is the hero block, and there is no page
+title to render in its place.
+
+---
+
+## Paginated list pages number their h1
+
+**Preferred:** `<h1>Blog (page 2)</h1>` on `/posts/page/2/` and up.
+
+**Rejected:** The same `<h1>Blog</h1>` on all 24 pages.
+
+**Why:** Twenty-four pages sharing one heading tells a reader arriving from
+search nothing about where they landed, and gives a crawler 24 identical
+top-level signals to reconcile. The page number is the only thing that
+distinguishes them, so it belongs in the heading. Page 1 stays unadorned.
+
+---
+
+## Cards on a list page are h2
+
+**Preferred:** `list.html` and `taxonomy.html` pass `headingLevel "h2"` to
+`post-card.html`.
+
+**Rejected:** The partial's `h3` default.
+
+**Why:** The cards sit directly under the page h1, so `h3` skips a level. The
+partial defaults to `h3` for callers that nest it under a section heading; a
+list page is not one of those. `taxonomy.html` already passed `h2` for this
+reason.
+
+---
+
+## Known gap: skipped levels inside old posts
+
+Seven posts in the pre-2023 archive jump levels inside the body (`h1` → `h3`,
+`h2` → `h4`). Those are markdown authoring artifacts, not a template problem,
+and they do not affect the h1 count. Untouched for now.

--- a/decisions/headings.md
+++ b/decisions/headings.md
@@ -24,8 +24,11 @@ The 38 came from two templates that rendered no heading of their own:
   through `page/23`; `page/1` is an alias redirect) opened straight into the
   post cards.
 - `_default/onepage.html` — rendered only `.Content`, so `/follow/`, `/now/`,
-  `/talks/`, `/values/`, and eleven `/projects/*` pages had nothing above the
-  body text.
+  `/talks/`, `/values/`, and eleven `/projects/*` pages had no `h1`. Most of
+  them did render a heading; it just started a level too deep. The eleven
+  project pages each opened with an `##` restating their own front-matter title,
+  and `/follow/` with `## RSS Feeds`. Only `/now/`, `/talks/`, and `/values/`
+  opened with body text and nothing else.
 
 Worse than the gap was the inconsistency it produced. Three different answers to
 the same question were live at once: `contact.md` reached for a
@@ -37,10 +40,43 @@ duplicating its own front-matter title one level too deep with no h1 above it.
 `_default/single.html` and `_default/taxonomy.html` already worked this way, so
 this is the existing pattern finishing its spread rather than a new one.
 
-The cost is real and was accepted: the fix visibly changed 15 pages that used to
-open with body text, and it required sweeping every markdown file that had been
-supplying its own heading. That sweep is a one-time price. The alternative,
-asking every future page to remember an `#` line, is a recurring one.
+The cost is real and was accepted. Twenty-three onepage files changed visibly:
+three (`/now/`, `/talks/`, `/values/`) gained a heading where there had been
+body text, `/follow/` gained one above its existing `## RSS Feeds`, and sixteen
+traded a heading they drew in markdown for the one the layout now draws. The
+last three were not in the audit's counts at all — `/contact/` swapped its
+screen-reader-only title for a visible one, `/elixir-consulting/` gained a plain
+`h1` above the serif pull quote that had been standing in as one, and
+`/projects/` gained one above the three section headings that used to be its
+h1s. `/posts/` and its 22 pagination pages gained a "Blog" heading on top of
+that.
+
+Sweeping every markdown file that had been supplying its own heading is a
+one-time price. The alternative, asking every future page to remember an `#`
+line, is a recurring one.
+
+---
+
+## The build enforces it
+
+**Preferred:** `bin/verify-headings.mjs`, run from `bin/build.sh`, fails the
+build if any non-alias page renders zero or two-plus `<h1>` tags.
+
+**Rejected:** Trusting the convention, documented here and in the archetype, to
+hold on its own.
+
+**Why:** Nothing about the setup keeps this swept. A post that opens with a `#`
+renders a second h1; a new layout that forgets the heading renders none. Neither
+is a Hugo error, neither is visible on the rendered page, and the drift that
+prompted this record accumulated for years precisely because nobody could see
+it. That is the same class of silent failure as a 404ing `og:image` (#159) or
+malformed JSON-LD, and it gets the same treatment. `/random/` is the script's one
+allowance, named by path rather than excused by a "skip noindex pages" rule that
+would stop checking `/search/` along with it.
+
+Issue #186 suggested folding this into the wider page-metadata check proposed in
+#156. It ships standalone instead — #156 is still unbuilt, and the invariant is
+newest and least settled right now, which is when a guard is worth the most.
 
 ---
 
@@ -56,8 +92,9 @@ the shortcode's only remaining job is suppressing a heading the page should
 have, and a second way to declare an h1 is exactly the ambiguity this decision
 removes. `/contact/` now shows "Contact" like every other page.
 
-Two layouts still declare a visually hidden h1 directly, and both are
-deliberate:
+Two layouts declare a visually hidden h1 directly, and both are deliberate.
+`home.html`'s predates this decision; `search.html`'s was added by it, since
+`/search/` had no h1 at all before:
 
 - `home.html` — `<h1 class="sr-only">Who is Mike Zornek?</h1>`. The home page's
   visual identity is the hero block, and there is no page title to draw in its
@@ -70,9 +107,10 @@ deliberate:
 `/search/` is `noindex`, so it sits outside the "every indexable page" scope
 above. It gets a heading anyway, because the reason for the rule is screen
 reader navigation as much as search engines, and `noindex` does not make a page
-unreachable. The one page with no `<h1>` on the whole site is `/random/`, which
-is not a page: it is a bare redirect shim whose body exists only as a fallback
-link if its script does not run.
+unreachable. The one non-alias page with no `<h1>` on the whole site is
+`/random/`, which is not really a page: it is a bare redirect shim whose body
+exists only as a fallback link if its script does not run. The other 189 files
+without one are Hugo's alias redirect stubs for the pre-2020 URL scheme.
 
 ---
 

--- a/decisions/headings.md
+++ b/decisions/headings.md
@@ -14,13 +14,15 @@ at `##`.
 
 **Why:** Content-owned h1s are opt-in, and the opt-in did not happen. A Bing
 Webmaster Tools scan in August 2026 flagged missing and duplicated h1s; a full
-audit of the build found **39 indexable pages with no `<h1>` at all** and
-**6 with more than one** (issue #186).
+audit of the build found **38 indexable pages with no `<h1>` at all** and
+**6 with more than one** (issue #186; the issue says 39, counted before the
+alias stub at `/posts/page/1/` was excluded).
 
-The 39 came from two templates that rendered no heading of their own:
+The 38 came from two templates that rendered no heading of their own:
 
-- `_default/list.html` — `/posts/` plus its 23 pagination pages opened straight
-  into the post cards.
+- `_default/list.html` — `/posts/` plus its 22 pagination pages (`page/2`
+  through `page/23`; `page/1` is an alias redirect) opened straight into the
+  post cards.
 - `_default/onepage.html` — rendered only `.Content`, so `/follow/`, `/now/`,
   `/talks/`, `/values/`, and eleven `/projects/*` pages had nothing above the
   body text.
@@ -54,22 +56,50 @@ the shortcode's only remaining job is suppressing a heading the page should
 have, and a second way to declare an h1 is exactly the ambiguity this decision
 removes. `/contact/` now shows "Contact" like every other page.
 
-`home.html` still emits `<h1 class="sr-only">Who is Mike Zornek?</h1>`. That one
-stays: the home page's visual identity is the hero block, and there is no page
-title to render in its place.
+Two layouts still declare a visually hidden h1 directly, and both are
+deliberate:
+
+- `home.html` — `<h1 class="sr-only">Who is Mike Zornek?</h1>`. The home page's
+  visual identity is the hero block, and there is no page title to draw in its
+  place.
+- `search.html` — `<h1 class="sr-only">{{ .Title }}</h1>`. The search form is
+  the whole page; a drawn "Search" heading above a box that says "Search blog
+  posts..." is redundant to a sighted reader but the page still needs a
+  top-level landmark to announce.
+
+`/search/` is `noindex`, so it sits outside the "every indexable page" scope
+above. It gets a heading anyway, because the reason for the rule is screen
+reader navigation as much as search engines, and `noindex` does not make a page
+unreachable. The one page with no `<h1>` on the whole site is `/random/`, which
+is not a page: it is a bare redirect shim whose body exists only as a fallback
+link if its script does not run.
 
 ---
 
-## Paginated list pages number their h1
+## Paginated list pages repeat the same h1
 
-**Preferred:** `<h1>Blog (page 2)</h1>` on `/posts/page/2/` and up.
+**Preferred:** The same `<h1>Blog</h1>` on all 23 list pages.
 
-**Rejected:** The same `<h1>Blog</h1>` on all 24 pages.
+**Rejected:** `<h1>Blog (page 2)</h1>` on `/posts/page/2/` and up.
 
-**Why:** Twenty-four pages sharing one heading tells a reader arriving from
-search nothing about where they landed, and gives a crawler 24 identical
-top-level signals to reconcile. The page number is the only thing that
-distinguishes them, so it belongs in the heading. Page 1 stays unadorned.
+**Why:** Numbering them looks like an improvement and buys nothing here. The
+two arguments for it both fail against how this site is actually built:
+
+- **Crawler disambiguation.** Every `/posts/page/N/` already emits
+  `<link rel="canonical" href="https://mikezornek.com/posts/">` and none of
+  them appear in `sitemap.xml`. A crawler is never asked to reconcile 23
+  competing top-level signals, because they all collapse to `/posts/`. For the
+  same reason nobody arrives on page 7 from a search result.
+- **Reader orientation.** `partials/pagination.html` already renders
+  "7 of 23" directly above and below the cards, on every paginated page.
+
+What numbering does cost is a mismatch. The page number would land in the `h1`
+only: `<title>` and `og:title` come from `head.html`, which has no paginator
+awareness, so page 7 would read "Blog (page 7)" in the body and "Blog" in the
+browser tab and share card. An `h1`/`title` disagreement is itself something
+Bing Webmaster Tools reports, which would be a poor trade for work prompted by
+a Bing scan. Numbering the heading is only worth revisiting alongside a
+`head.html` that numbers the title with it.
 
 ---
 
@@ -92,3 +122,9 @@ reason.
 Seven posts in the pre-2023 archive jump levels inside the body (`h1` → `h3`,
 `h2` → `h4`). Those are markdown authoring artifacts, not a template problem,
 and they do not affect the h1 count. Untouched for now.
+
+`/search/` skips a level too, once results render: its `h1` is followed by the
+`h3` each result uses. Left alone deliberately. The result headings take their
+size from the prose defaults rather than a utility class, so promoting them to
+`h2` would visibly enlarge every result, and that is a design change on a
+`noindex` page rather than the heading fix this work was scoped to.

--- a/themes/reborn/archetypes/default.md
+++ b/themes/reborn/archetypes/default.md
@@ -1,4 +1,6 @@
 ---
+# The layout renders this title as the page's only h1, so the body below starts
+# at `##` and never writes a `#`. See decisions/headings.md.
 title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}
 description: "something tweet like"

--- a/themes/reborn/layouts/_default/list.html
+++ b/themes/reborn/layouts/_default/list.html
@@ -4,15 +4,10 @@
       <div
         class="prose prose-p:leading-[1.5] prose-headings:mb-2 prose-a:text-purple-600 prose-a:visited:text-purple-900 max-w-none"
       >
-        {{/* The layout owns the page h1. The page number keeps each paginated
-          page's heading distinct from the other 22. See decisions/headings.md.
+        {{/* The layout owns the page h1. Paginated pages repeat it unchanged;
+          see decisions/headings.md for why they do not carry a page number.
         */}}
-        <h1>
-          {{- .Title }}
-          {{- if gt .Paginator.PageNumber 1 }}
-            (page {{ .Paginator.PageNumber }})
-          {{ end -}}
-        </h1>
+        <h1>{{ .Title }}</h1>
 
         {{ if and (eq .Section "posts") (eq .Paginator.PageNumber 1) }}
           <div class="flex flex-col gap-x-8 md:flex-row md:items-start">

--- a/themes/reborn/layouts/_default/list.html
+++ b/themes/reborn/layouts/_default/list.html
@@ -4,6 +4,16 @@
       <div
         class="prose prose-p:leading-[1.5] prose-headings:mb-2 prose-a:text-purple-600 prose-a:visited:text-purple-900 max-w-none"
       >
+        {{/* The layout owns the page h1. The page number keeps each paginated
+          page's heading distinct from the other 22. See decisions/headings.md.
+        */}}
+        <h1>
+          {{- .Title }}
+          {{- if gt .Paginator.PageNumber 1 }}
+            (page {{ .Paginator.PageNumber }})
+          {{ end -}}
+        </h1>
+
         {{ if and (eq .Section "posts") (eq .Paginator.PageNumber 1) }}
           <div class="flex flex-col gap-x-8 md:flex-row md:items-start">
             <div class="md:flex-[7] md:pt-5">
@@ -17,8 +27,9 @@
 
         {{ partial "pagination.html" . }}
 
+        {{/* Cards sit directly under this page's h1, so their title is an h2. */}}
         {{ range .Paginator.Pages }}
-          {{ partial "post-card.html" (dict "page" .) }}
+          {{ partial "post-card.html" (dict "page" . "headingLevel" "h2") }}
         {{ end }}
 
         {{ partial "pagination.html" . }}

--- a/themes/reborn/layouts/_default/onepage.html
+++ b/themes/reborn/layouts/_default/onepage.html
@@ -5,6 +5,10 @@
       <article
         class="prose prose-p:leading-[1.5] prose-headings:mb-2 prose-a:text-purple-600 prose-a:visited:text-purple-900 max-w-none"
       >
+        {{/* The layout owns the page h1; markdown starts at h2. See
+          decisions/headings.md.
+        */}}
+        <h1>{{ .Title }}</h1>
         {{ .Content }}
       </article>
     </div>

--- a/themes/reborn/layouts/_default/search.html
+++ b/themes/reborn/layouts/_default/search.html
@@ -1,6 +1,12 @@
 {{ define "main" }}
   <main id="main-content" tabindex="-1">
     <div class="mx-auto max-w-screen-md px-4 md:px-0">
+      {{/* The layout owns the page h1. See decisions/headings.md. The form is
+        the page's whole visual identity, so this one is announced rather than
+        drawn.
+      */}}
+      <h1 class="sr-only">{{ .Title }}</h1>
+
       {{ partial "search-form.html" . }}
 
       {{ partial "search-external.html" (dict "extraClass" "-mt-4 mb-8") }}

--- a/themes/reborn/layouts/shortcodes/consulting-quote.html
+++ b/themes/reborn/layouts/shortcodes/consulting-quote.html
@@ -1,7 +1,8 @@
 <div class="not-prose ml-4 flex flex-row items-center">
-  <h1 class="not-prose font-serif text-4xl italic">
+  {{/* A pull quote, not a heading: the layout owns this page's h1. */}}
+  <p class="not-prose font-serif text-4xl italic">
     “Helping Elixir teams scale faster, reduce technical debt, and ship with
     confidence.”
-  </h1>
+  </p>
   {{ partial "zorn-avatar.html" . }}
 </div>

--- a/themes/reborn/layouts/shortcodes/sr-only-title.html
+++ b/themes/reborn/layouts/shortcodes/sr-only-title.html
@@ -1,1 +1,0 @@
-<h1 class="sr-only">{{ .Get 0 }}</h1>


### PR DESCRIPTION
Closes #186.

Every non-alias page now renders exactly one `<h1>`, and the layout is what renders it. Verified against a real build of both branches: `main` has 38 indexable pages with no h1 and 6 with more than one; this branch has zero of either, with `/random/` the only page still without one.

**The templates.** `onepage.html` and `list.html` now emit `<h1>{{ .Title }}</h1>`, joining `single.html` and `taxonomy.html`, which already worked this way. `list.html` also passes `headingLevel "h2"` to `post-card.html` so the cards under the new page h1 stop skipping a level.

**The sweep.** Twenty-three markdown files gave up a heading they were drawing themselves, and five posts had a mid-post `#` demoted to `##`. The `sr-only-title` shortcode is deleted: once the layout renders a heading unconditionally, its only job was suppressing one.

**The guard.** `bin/verify-headings.mjs` runs from `bin/build.sh` and fails the build on any page with zero or two-plus h1s. Without it the sweep silently rots, the same way three posts shipped broken `og:image` paths for months before #159. `/random/` is a named path allowance, not a "skip noindex pages" rule, so `/search/` stays covered. This also tightens alias detection in `verify-og-images.mjs`, which shared a regex loose enough to skip any page containing a meta refresh tag.

**The record.** `decisions/headings.md` covers why the layout owns the h1, why paginated pages repeat the same one rather than numbering it, why two layouts keep a screen-reader-only heading, and what was left alone.

Three pages change visibly beyond the ones the issue counted: `/contact/` swaps its screen-reader-only title for a visible one, `/elixir-consulting/` gains a plain h1 above its serif pull quote (which had been an `<h1>` for styling), and `/projects/` gains one above its three section headings.