### PR TITLE
Add anchor links to blog post headings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@
 # glues attributes together (e.g. `alt="x"width="y"`) — malformed output. And
 # figure.html the plugin can't even print ("invalid node root"). See issue #114.
 themes/reborn/layouts/_markup/render-image.html
+themes/reborn/layouts/_markup/render-heading.html
 themes/reborn/layouts/shortcodes/figure.html
 
 # Go templates that happen to end in `.json`. Prettier picks the JSON parser off

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -14,7 +14,7 @@ not the site. I've been unable to host them in the `themes` folder so far. */
 /* Heading anchor links on blog posts (issue #194). scroll-margin-top keeps a
    linked section off the very top edge of the viewport when it lands; the
    `.heading-anchor` marker styling follows below. */
-.prose :is(h2, h3) {
+.prose :is(h2, h3):has(> .heading-anchor) {
   scroll-margin-top: 2rem;
 }
 .prose .heading-anchor {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -18,14 +18,25 @@ not the site. I've been unable to host them in the `themes` folder so far. */
   scroll-margin-top: 2rem;
 }
 .prose .heading-anchor {
+  position: relative;
   margin-left: 0.35em;
   font-weight: 400;
   text-decoration: none;
   color: var(--color-purple-600);
 }
+/* The `#` glyph is drawn here, not emitted as DOM text, so it stays out of the
+   search index and the RSS feed (see the render hook). */
+.prose .heading-anchor::before {
+  content: "#";
+}
+/* The "Copied" confirmation is absolutely positioned so it never reserves
+   layout space beside the marker, which would otherwise gap or wrap headings. */
 .prose .heading-anchor::after {
   content: "Copied";
+  position: absolute;
+  left: 100%;
   margin-left: 0.4em;
+  white-space: nowrap;
   font-size: 0.75rem;
   color: var(--color-gray-500);
   opacity: 0;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -11,6 +11,42 @@ not the site. I've been unable to host them in the `themes` folder so far. */
   white-space: nowrap;
 }
 
+/* Heading anchor links on blog posts (issue #194). scroll-margin-top keeps a
+   linked section off the very top edge of the viewport when it lands; the
+   `.heading-anchor` marker styling follows below. */
+.prose :is(h2, h3) {
+  scroll-margin-top: 2rem;
+}
+.prose .heading-anchor {
+  margin-left: 0.35em;
+  font-weight: 400;
+  text-decoration: none;
+  color: var(--color-purple-600);
+}
+.prose .heading-anchor::after {
+  content: "Copied";
+  margin-left: 0.4em;
+  font-size: 0.75rem;
+  color: var(--color-gray-500);
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out;
+}
+.prose .heading-anchor.is-copied::after {
+  opacity: 1;
+}
+/* Reveal the marker on hover only where a hover pointer exists. On touch
+   devices (no hover) it stays visible so the affordance is reachable. */
+@media (hover: hover) {
+  .prose .heading-anchor {
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out;
+  }
+  .prose :is(h2, h3):hover > .heading-anchor,
+  .prose .heading-anchor:focus {
+    opacity: 1;
+  }
+}
+
 /* Download fonts: https://gwfh.mranftl.com/fonts/ubuntu?subsets=latin */
 
 /* ubuntu-regular - latin */

--- a/themes/reborn/assets/js/main.js
+++ b/themes/reborn/assets/js/main.js
@@ -60,6 +60,24 @@ document.addEventListener("submit", trackNewsletterSignup);
 // address-bar hash on its own. On top of that, copy the section's full URL to
 // the clipboard so the reader can paste a deep link, with a brief "Copied"
 // flash for feedback.
+
+// The "Copied" flash is visual only, so a polite live region announces the copy
+// to assistive tech. One shared, visually hidden node, created on first use.
+function headingAnchorStatus() {
+  var el = document.getElementById("heading-anchor-status");
+  if (el) {
+    return el;
+  }
+  el = document.createElement("div");
+  el.id = "heading-anchor-status";
+  el.setAttribute("role", "status");
+  el.setAttribute("aria-live", "polite");
+  el.style.cssText =
+    "position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0;";
+  document.body.appendChild(el);
+  return el;
+}
+
 function copyHeadingAnchorLink(event) {
   var link = event.target.closest && event.target.closest("a.heading-anchor");
   if (!link) {
@@ -73,8 +91,13 @@ function copyHeadingAnchorLink(event) {
   navigator.clipboard.writeText(link.href).then(
     function () {
       link.classList.add("is-copied");
+      var status = headingAnchorStatus();
+      status.textContent = "Link copied";
       setTimeout(function () {
         link.classList.remove("is-copied");
+        // Clear the announcement so the next copy is a genuine change, which is
+        // what a live region needs to re-announce identical text.
+        status.textContent = "";
       }, 1200);
     },
     function () {},

--- a/themes/reborn/assets/js/main.js
+++ b/themes/reborn/assets/js/main.js
@@ -52,3 +52,33 @@ function trackNewsletterSignup(event) {
 }
 
 document.addEventListener("submit", trackNewsletterSignup);
+
+// --- Heading anchor links (issue #194) -------------------------------------
+//
+// The posts heading render hook adds a `.heading-anchor` link to each h2/h3.
+// The link's href is `#slug`, so the browser handles the in-page jump and the
+// address-bar hash on its own. On top of that, copy the section's full URL to
+// the clipboard so the reader can paste a deep link, with a brief "Copied"
+// flash for feedback.
+function copyHeadingAnchorLink(event) {
+  var link = event.target.closest && event.target.closest("a.heading-anchor");
+  if (!link) {
+    return;
+  }
+  // Without the async Clipboard API, leave the native hash navigation to stand
+  // on its own rather than swallowing the click.
+  if (!navigator.clipboard) {
+    return;
+  }
+  navigator.clipboard.writeText(link.href).then(
+    function () {
+      link.classList.add("is-copied");
+      setTimeout(function () {
+        link.classList.remove("is-copied");
+      }, 1200);
+    },
+    function () {},
+  );
+}
+
+document.addEventListener("click", copyHeadingAnchorLink);

--- a/themes/reborn/layouts/_markup/render-heading.html
+++ b/themes/reborn/layouts/_markup/render-heading.html
@@ -1,0 +1,21 @@
+{{- /*
+  Heading render hook (see issue #194).
+
+  Hugo already emits GitHub-style slug `id`s on every content heading, so the
+  deep-link targets exist. This hook adds the visible affordance: a `#` marker
+  on blog-post h2/h3 that copies the section's URL (the clipboard copy is wired
+  up in themes/reborn/assets/js/main.js).
+
+  A render hook replaces heading rendering site-wide, so the base output below
+  must reproduce Hugo's default `<hN id="…">…</hN>` for every page; only posts
+  h2/h3 get the extra anchor.
+*/ -}}
+{{- $showAnchor := and (eq .Page.Type "posts") (in (slice 2 3) .Level) -}}
+<h{{ .Level }} id="{{ .Anchor }}"
+  {{- range $k, $v := .Attributes }}{{ if ne $k "id" }} {{ $k }}="{{ $v }}"{{ end }}{{ end -}}
+>
+  {{- .Text -}}
+  {{- if $showAnchor }}
+    <a class="heading-anchor" href="#{{ .Anchor }}" aria-label="Copy link to this section"><span aria-hidden="true">#</span></a>
+  {{- end -}}
+</h{{ .Level }}>

--- a/themes/reborn/layouts/_markup/render-heading.html
+++ b/themes/reborn/layouts/_markup/render-heading.html
@@ -6,6 +6,11 @@
   on blog-post h2/h3 that copies the section's URL (the clipboard copy is wired
   up in themes/reborn/assets/js/main.js).
 
+  The anchor is emitted as an EMPTY <a>; its `#` glyph comes from CSS
+  (`.heading-anchor::before`), not DOM text. Kept out of the DOM, the marker
+  never leaks into `.Plain` (the JSON search index) or `.Content` (the RSS
+  feed), where a stray `#` would otherwise land after every heading.
+
   A render hook replaces heading rendering site-wide, so the base output below
   must reproduce Hugo's default `<hN id="…">…</hN>` for every page; only posts
   h2/h3 get the extra anchor.
@@ -16,6 +21,6 @@
 >
   {{- .Text -}}
   {{- if $showAnchor }}
-    <a class="heading-anchor" href="#{{ .Anchor }}" aria-label="Copy link to this section"><span aria-hidden="true">#</span></a>
+    <a class="heading-anchor" href="#{{ .Anchor }}" aria-label="Copy link to this section"></a>
   {{- end -}}
 </h{{ .Level }}>


### PR DESCRIPTION
Closes #194.

Readers can already deep-link to any section — Hugo emits GitHub-style slug `id`s on every content heading — but there was no visible way to grab that link. This adds the affordance: a `#` marker on blog-post h2/h3 that copies the section's full URL.

No production behavior changes outside blog posts. The heading render hook reproduces Hugo's default `<hN id="…">…</hN>` for every other page, so projects, `now`, `values`, and the rest render exactly as before. There is no test suite; verification was a clean `hugo` build plus inspecting the rendered HTML for posts (marker present, single `id`) and non-posts (plain headings, no marker).

## How it works

A heading render hook at [`themes/reborn/layouts/_markup/render-heading.html`](themes/reborn/layouts/_markup/render-heading.html) appends an `<a class="heading-anchor" href="#slug">#</a>` to a heading, scoped to `.Page.Type == "posts"` and levels 2–3. The `href` is the in-page anchor, so the browser owns the jump and the address-bar hash on its own. A small handler in [`themes/reborn/assets/js/main.js`](themes/reborn/assets/js/main.js) layers the clipboard copy on top and flashes a brief "Copied". CSS in [`assets/css/main.css`](assets/css/main.css) reveals the marker on hover where a hover pointer exists (always visible on touch), and adds `scroll-margin-top` so a linked section doesn't land jammed against the top.

## Seeing it

`hugo server`, then open any post with sections, e.g. `/posts/2013/6/week-in-review-wwdc-e3-and-cocoaheads/`. Hover a section heading — a muted `#` fades in to its right. Click it: the page jumps to that section, the URL gains the `#slug`, and the marker flashes "Copied" with the full deep-link URL on your clipboard. On a phone the `#` is always visible.

## Worth a reviewer's attention

- **No screenshot.** The marker is a hover-only state; a static shot would either miss it or misrepresent the default clean heading. The demo path above shows it live in one command.
- **The "Copied" flash is beyond the issue's letter.** The issue settled "copy + update hash"; a visible confirmation wasn't named. I added it because a silent clipboard copy leaves the reader unsure it worked. Approved in review, but easy to strip if you'd rather.
- **Touch/narrow handling keys off `@media (hover: hover)`, not viewport width.** A narrow desktop window with a mouse keeps the hover-reveal (marker hidden until hover) rather than pinning the `#` on. This matches what we settled: "no hover there → always visible" is about pointer capability, not screen size.
- **The hook is on `.prettierignore`.** The go-template plugin can't print a dynamic tag name (`<h{{ .Level }}>`) — same "invalid node root" failure that already exempts the sibling `render-image.html`.
