### PR TITLE
Add post: Who Fills the Sprint? My 45/45/10 Split

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ hugo server
 To make a new post:
 
 ```bash
-hugo new posts/2026/7/pitch-three-years-of-evolving-ai-workflows/index.md
+hugo new posts/2026/8/who-fills-the-sprint/index.md
 ```
 
 ## The `reborn` theme.

--- a/codebook.toml
+++ b/codebook.toml
@@ -7,4 +7,5 @@ words = [
     "cucumbered",
     "journaling",
     "lifecycle",
+    "overengineered",
 ]

--- a/content/posts/2026/8/who-fills-the-sprint/index.md
+++ b/content/posts/2026/8/who-fills-the-sprint/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Who Fills the Sprint? My 45/45/10 Split"
-date: 2026-08-17T09:55:08-04:00
+date: 2026-08-18T09:00:00-04:00
 description: "Every sprint is a tug-of-war between the roadmap and the work that keeps the lights on. Here is the 45/45/10 split I plan against, and why."
 pain: "Sprint planning turns into a tug-of-war, and whoever pushes hardest wins, so the losing team quietly resents the plan."
 fix: "Name the three claimants on a sprint and give each a standing percentage instead of re-fighting the argument every two weeks."

--- a/content/posts/2026/8/who-fills-the-sprint/index.md
+++ b/content/posts/2026/8/who-fills-the-sprint/index.md
@@ -12,7 +12,7 @@ tags:
 
 Every project has way more things to do than resources allotted. That is a given for pretty much any human endeavor. Figuring out what to work on is the interesting part.
 
-When it comes to software development, most teams plan work in time-boxed ranges, often called sprints.[^1] Let's generalize and say two teams are contributing to this work: the business/product owners and the engineering team. Each has its own interests.
+When it comes to software development, most companies plan work in time-boxed ranges, often called sprints.[^1] Let's generalize and say two teams are contributing to this work: the business/product owners and the engineering team. Each has its own interests.
 
 The **business/product owners** are usually focused on features and enhancements that grow the business. Sometimes these are time-sensitive, to meet a contract requirement, hit an annual cycle for customers, or keep a promise made to company ownership. If you are a young company, you might still be trying to prove the business is viable on a limited runway.
 

--- a/content/posts/2026/8/who-fills-the-sprint/index.md
+++ b/content/posts/2026/8/who-fills-the-sprint/index.md
@@ -2,7 +2,7 @@
 title: "Who Fills the Sprint? My 45/45/10 Split"
 date: 2026-08-17T09:55:08-04:00
 description: "Every sprint is a tug-of-war between the roadmap and the work that keeps the lights on. Here is the 45/45/10 split I plan against, and why."
-pain: "Sprint planning turns into a tug-of-war, and whoever pushes hardest wins, so the losing camp quietly resents the plan."
+pain: "Sprint planning turns into a tug-of-war, and whoever pushes hardest wins, so the losing team quietly resents the plan."
 fix: "Name the three claimants on a sprint and give each a standing percentage instead of re-fighting the argument every two weeks."
 bob-promise: "After reading, you will have a defensible split to bring to your next planning meeting."
 tags:
@@ -20,7 +20,7 @@ The **engineering team** owns the work of bringing that vision to life through c
 
 ## Keeping everyone happy (or at least less frustrated)
 
-When you plan your sprints, you need to keep these two camps in balance.
+When you plan your sprints, you need to keep these two teams in balance.
 
 Let the business/product owners dictate it all, and you may validate the business idea or sign that new contract, but you are left with an unstable mess of software. That leads to customer and employee churn, or worse, people talking on social media about your platform downtime and security breaches.
 

--- a/content/posts/2026/8/who-fills-the-sprint/index.md
+++ b/content/posts/2026/8/who-fills-the-sprint/index.md
@@ -1,0 +1,41 @@
+---
+title: "Who Fills the Sprint? My 45/45/10 Split"
+date: 2026-08-17T09:55:08-04:00
+description: "Every sprint is a tug-of-war between the roadmap and the work that keeps the lights on. Here is the 45/45/10 split I plan against, and why."
+pain: "Sprint planning turns into a tug-of-war, and whoever pushes hardest wins, so the losing camp quietly resents the plan."
+fix: "Name the three claimants on a sprint and give each a standing percentage instead of re-fighting the argument every two weeks."
+bob-promise: "After reading, you will have a defensible split to bring to your next planning meeting."
+tags:
+  - practices
+  - career
+---
+
+Every project has way more things to do than resources allotted. That is a given for pretty much any human endeavor. Figuring out what to work on is the interesting part.
+
+When it comes to software development, most teams plan work in time-boxed ranges, often called sprints.[^1] Let's generalize and say two teams are contributing to this work: the business/product owners and the engineering team. Each has its own interests.
+
+The **business/product owners** are usually focused on features and enhancements that grow the business. Sometimes these are time-sensitive, to meet a contract requirement, hit an annual cycle for customers, or keep a promise made to company ownership. If you are a young company, you might still be trying to prove the business is viable on a limited runway.
+
+The **engineering team** owns the work of bringing that vision to life through code. They also carry a set of assumed responsibilities. Building construction requires fire suppression. Doctors order routine lab work to assess their patients' health. Engineers are professionals in the same way, with unspoken work that must happen to deliver a safe and healthy environment. Some examples: maintaining verified backup systems, watching production for errors and anomalies, triaging those findings into future work and fixes, updating software to close known security vulnerabilities, and keeping a software stack that is, for lack of a better word, [good](/posts/2026/7/what-is-good-code/).
+
+## Keeping everyone happy (or at least less frustrated)
+
+When you plan your sprints, you need to keep these two camps in balance.
+
+Let the business/product owners dictate it all, and you may validate the business idea or sign that new contract, but you are left with an unstable mess of software. That leads to customer and employee churn, or worse, people talking on social media about your platform downtime and security breaches.
+
+Let the engineers have too big a say, and you can end up with overengineered features no one uses, or great uptime for a user count that does not sustain the business.
+
+The other people who need some influence are **the individuals** who make up these teams. They each have their own itches to scratch. Giving them room to work on what they think is important, even if it moves slowly across multiple sprints, feeds their sense of [autonomy](https://www.danpink.com/books/drive/#:~:text=Autonomy%20is%20having%20a%20measure%20of%20control%20over%20what%20we%20do%20and%20how%20we%20do%20it%2E) and their satisfaction at work.
+
+The company (hopefully) hired these people not as nameless workers, but as distinct and diverse contributors who bring a personal perspective in addition to their raw execution. If that is true, you need to give them some sun and space to grow.
+
+## Percentages
+
+Here is how I think about it: 45% of the planned work comes from the business/product owners, 45% from the engineering team, and 10% from individual autonomy. Those numbers can and will shift over time, but that is the average I'd aim for in the long run.[^2]
+
+I'd be curious to hear how your own team plans its work. [Let me know.](/contact)
+
+[^1]: There is a particular frustration in asking your team to sprint endlessly. The word means "run at full speed over a short distance." You can't run full speed for the entire race. Also, this is not a race; the work never ends.
+
+[^2]: Worth noting: I am biased as someone who prefers engineering-led businesses. I'm sure there are plenty of "successful" MBAs who would give the engineering team a much lower percentage and still find "success".


### PR DESCRIPTION
A new post on how a sprint gets divided between product work, engineering upkeep, and the individuals doing the work, landing on a 45/45/10 split. It has no `draft` flag, so merging publishes it and Render deploys it live. The README's `hugo new` example also moves to this post's slug, replacing a path that no longer exists.

No template, theme, or config changes here. The post is an ordinary page bundle taking a generated social card, and I ran the production verification steps locally against the pinned Hugo 0.161.1: `verify-og-images`, `verify-structured-data`, and `verify-page-metadata` all pass, with the 139-character description well inside the 160 ceiling.

## The post argues for a number, not a principle

It names three claimants on a sprint and gives each a standing percentage, so the split is settled once instead of re-argued every two weeks. Front matter carries the `pain`/`fix`/`bob-promise` fields and the existing `practices` and `career` tags.

## Worth a reviewer's attention

- **The `## Individual autonomy` heading is gone**, merged into "Keeping everyone happy." That section now carries two ideas, and the post's in-page outline drops from three headings to two.
- **No commit on this branch carries `[skip render]`.** This repo's squash message is `COMMIT_MESSAGES`, so a marker in any commit here would be copied into the merge commit on `main` and suppress the deploy of a post that is now published.
- **The title is number-forward** at 39 characters, or 53 with the ` • Mike Zornek` suffix, so it stays under the 60-character ceiling tracked in #187.
- **`teams` is the settled term** for the two groups claiming a sprint, replacing a mixed use of `teams` and `camps`. One leftover reads a little close: line 15 uses "most teams" for development teams generally and "two teams" for the two claimants in the same sentence pair.

## Promotion

This is a practices/career post, **not an Elixir post**, so the Elixir column of the venue list is skipped: no Elixir Slack, Forum, ElixirStatus, Discord, Elixir Radar, or LinkedIn Elixir Group, and no `#ElixirLang`/`#MyElixirStatus` tags. That leaves the general-audience venues.

First, once the deploy is live, ping the search indexes:

```bash
bin/indexnow.sh https://mikezornek.com/posts/2026/8/who-fills-the-sprint/
```

**Venues to share on** (source vocabulary and per-venue tagged links). `utm_campaign` stays `who-fills-the-sprint` everywhere; only `utm_source` changes.

| Venue | `utm_source` | Tagged link |
|---|---|---|
| LinkedIn — the qualified one; the only venue that produced a signup in week one, and a business/practices post plays to its audience | `linkedin` | `https://mikezornek.com/posts/2026/8/who-fills-the-sprint/?utm_source=linkedin&utm_campaign=who-fills-the-sprint` |
| Bluesky — runs ~5:1 better than Mastodon for me | `bluesky` | `https://mikezornek.com/posts/2026/8/who-fills-the-sprint/?utm_source=bluesky&utm_campaign=who-fills-the-sprint` |
| Mastodon | `mastodon` | `https://mikezornek.com/posts/2026/8/who-fills-the-sprint/?utm_source=mastodon&utm_campaign=who-fills-the-sprint` |
| X / Twitter | `twitter` | `https://mikezornek.com/posts/2026/8/who-fills-the-sprint/?utm_source=twitter&utm_campaign=who-fills-the-sprint` |
| 30x500 Slack (share as an ebomb) — the pain/dream/fix framing fits this crowd | `30x500` | `https://mikezornek.com/posts/2026/8/who-fills-the-sprint/?utm_source=30x500&utm_campaign=who-fills-the-sprint` |
| Philly Cocoa Slack | `philly-cocoa` | `https://mikezornek.com/posts/2026/8/who-fills-the-sprint/?utm_source=philly-cocoa&utm_campaign=who-fills-the-sprint` |

Reddit r/elixir does not fit this post, so skip it unless a general dev subreddit is worth a one-off.

**Copy — hook-first (template B, the current default):**

> Every sprint is a tug-of-war between the roadmap and the work that keeps the lights on.
>
> Here's the 45/45/10 split I plan against, and why naming it once beats re-fighting it every two weeks.
>
> https://mikezornek.com/posts/2026/8/who-fills-the-sprint/?utm_source=bluesky&utm_campaign=who-fills-the-sprint
>
> #SoftwareDevelopment

**Hashtags:** software-craft post, so `#SoftwareDevelopment` (or `#Programming`) on Mastodon and LinkedIn; two or three at most, on their own line after the link. No AI tag — the post isn't about AI. Drop hashtags entirely on Reddit and in the Slack venues.

Bluesky mechanics still apply: paste the URL to generate a link card, then delete the raw URL from the text so the tagged link costs zero of the 300 characters.
